### PR TITLE
feat: export default encoder/decoder for pre-setting table URL parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,26 @@ Create an input that supports IME conversion with a uncontrolled component.
 
 - [sample code](https://github.com/taro-28/tanstack-table-search-params/tree/main/examples/lib/src/components/SearchInput.tsx)
 
+### Q: How can I preset query parameters when navigating to a page that contains a table?
+
+To pass initial table state via the URL, call one of the `encode*` helpers from  
+`tanstack-table-search-params/encoder-decoder` and assign its return value to your link.
+
+```tsx
+import { encodeSorting } from "tanstack-table-search-params/encoder-decoder";
+
+<Link
+  href={{
+    pathname: "/some-page-with-table",
+    query: {
+      sorting: encodeSorting([{ id: "name", desc: true }]),
+    },
+  }}
+>
+  foo
+</Link>;
+```
+
 ## Supported
 
 List of supported TanStack table states
@@ -272,3 +292,7 @@ MIT
 [1]: https://www.npmjs.com/package/tanstack-table-search-params
 [2]: https://github.com/taro-28/tanstack-table-search-params
 [3]: https://bundlephobia.com/package/tanstack-table-search-params
+
+```
+
+```

--- a/packages/tanstack-table-search-params/README.md
+++ b/packages/tanstack-table-search-params/README.md
@@ -241,6 +241,26 @@ Create an input that supports IME conversion with a uncontrolled component.
 
 - [sample code](https://github.com/taro-28/tanstack-table-search-params/tree/main/examples/lib/src/components/SearchInput.tsx)
 
+### Q: How can I preset query parameters when navigating to a page that contains a table?
+
+To pass initial table state via the URL, call one of the `encode*` helpers from  
+`tanstack-table-search-params/encoder-decoder` and assign its return value to your link.
+
+```tsx
+import { encodeSorting } from "tanstack-table-search-params/encoder-decoder";
+
+<Link
+  href={{
+    pathname: "/some-page-with-table",
+    query: {
+      sorting: encodeSorting([{ id: "name", desc: true }]),
+    },
+  }}
+>
+  foo
+</Link>;
+```
+
 ## Supported
 
 List of supported TanStack table states

--- a/packages/tanstack-table-search-params/package.json
+++ b/packages/tanstack-table-search-params/package.json
@@ -46,6 +46,11 @@
       "types": "./dist/index.d.ts",
       "require": "./dist/index",
       "import": "./dist/index.mjs"
+    },
+    "./encoder-decoder": {
+      "types": "./dist/encoder-decoder/index.d.ts",
+      "require": "./dist/encoder-decoder/index",
+      "import": "./dist/encoder-decoder/index.mjs"
     }
   },
   "main": "./dist/index",

--- a/packages/tanstack-table-search-params/src/encoder-decoder/columnFilters.test.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/columnFilters.test.ts
@@ -378,7 +378,10 @@ describe("columnFilters", () => {
       defaultDefaultColumnFilters,
       customDefaultValue,
     ])("default value: $defaultValue", (...defaultValue) =>
-      test.each<{ name: string; stateValue: DefaultValue }>([
+      test.each<{
+        name: string;
+        stateValue: Parameters<typeof encodeColumnFilters>[0];
+      }>([
         {
           name: "default value",
           stateValue: defaultValue,

--- a/packages/tanstack-table-search-params/src/encoder-decoder/columnFilters.test.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/columnFilters.test.ts
@@ -3,6 +3,10 @@ import { defaultDefaultColumnFilters } from "../useColumnFilters";
 import { decodeColumnFilters, encodeColumnFilters } from "./columnFilters";
 import { noneStringForCustomDefaultValue } from "./noneStringForCustomDefaultValue";
 
+type DefaultValue = NonNullable<
+  NonNullable<Parameters<typeof encodeColumnFilters>[1]>["defaultValue"]
+>;
+
 const customDefaultValue = [
   {
     id: "custom",
@@ -12,7 +16,7 @@ const customDefaultValue = [
 
 describe("columnFilters", () => {
   describe("encode", () =>
-    describe.each<Parameters<typeof encodeColumnFilters>[1]>([
+    describe.each<DefaultValue>([
       defaultDefaultColumnFilters,
       customDefaultValue,
     ])("default value: %defaultValue", (...defaultValue) =>
@@ -174,7 +178,7 @@ describe("columnFilters", () => {
           want: "foo.%5B%22bar%22%2C42%2Ctrue%2Cnull%2C%7B%22bar%22%3A%22baz%22%7D%2C%5B%22qux%22%5D%5D",
         },
       ])("$name", ({ stateValue, want }) =>
-        expect(encodeColumnFilters(stateValue, defaultValue)).toEqual(want),
+        expect(encodeColumnFilters(stateValue, { defaultValue })).toEqual(want),
       ),
     ));
 
@@ -189,7 +193,7 @@ describe("columnFilters", () => {
         }>([
           {
             name: "default value",
-            queryValue: encodeColumnFilters(defaultValue, defaultValue),
+            queryValue: encodeColumnFilters(defaultValue, { defaultValue }),
             want: defaultValue,
           },
           {
@@ -363,19 +367,18 @@ describe("columnFilters", () => {
             want: defaultValue,
           },
         ])("$name", ({ queryValue, want }) =>
-          expect(decodeColumnFilters(queryValue, defaultValue)).toEqual(want),
+          expect(decodeColumnFilters(queryValue, { defaultValue })).toEqual(
+            want,
+          ),
         ),
     ));
 
   describe("encode and decode", () =>
-    describe.each<Parameters<typeof encodeColumnFilters>[1]>([
+    describe.each<DefaultValue>([
       defaultDefaultColumnFilters,
       customDefaultValue,
     ])("default value: $defaultValue", (...defaultValue) =>
-      test.each<{
-        name: string;
-        stateValue: Parameters<typeof encodeColumnFilters>[1];
-      }>([
+      test.each<{ name: string; stateValue: DefaultValue }>([
         {
           name: "default value",
           stateValue: defaultValue,
@@ -493,8 +496,8 @@ describe("columnFilters", () => {
       ])("$name", ({ stateValue }) => {
         expect(
           decodeColumnFilters(
-            encodeColumnFilters(stateValue, defaultValue),
-            defaultValue,
+            encodeColumnFilters(stateValue, { defaultValue }),
+            { defaultValue },
           ),
         ).toEqual(stateValue);
       }),

--- a/packages/tanstack-table-search-params/src/encoder-decoder/columnFilters.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/columnFilters.ts
@@ -1,21 +1,35 @@
-import type { State } from "..";
+import type { State as TanstackTableState } from "..";
 import type { Query } from "../types";
 import { noneStringForCustomDefaultValue } from "./noneStringForCustomDefaultValue";
 
+/**
+ * The default encoder of Tanstack Table's `columnFilters`.
+ *
+ * @param value - The value to encode.
+ * @param options
+ * @param options.defaultValue
+ * - If you set [`defaultValues`](https://github.com/taro-28/tanstack-table-search-params?tab=readme-ov-file#custom-default-value) in `useTableSearchParams`,
+ * you should set the same value.
+ *
+ * @returns The encoded query parameter value.
+ */
 export const encodeColumnFilters = (
-  stateValue: State["columnFilters"],
-  defaultValue: State["columnFilters"],
+  value: TanstackTableState["columnFilters"],
+  options?: {
+    defaultValue?: TanstackTableState["columnFilters"];
+  },
 ): Query[string] => {
-  if (JSON.stringify(stateValue) === JSON.stringify(defaultValue)) {
+  const defaultValue = options?.defaultValue;
+  if (JSON.stringify(value) === JSON.stringify(defaultValue)) {
     return undefined;
   }
 
   // return encoded empty string if stateValue is empty with custom default value
-  if (stateValue.length === 0) {
+  if (value.length === 0) {
     return noneStringForCustomDefaultValue;
   }
 
-  return stateValue
+  return value
     .map(
       ({ id, value }) =>
         `${id}.${encodeURIComponent(JSON.stringify(value)).replaceAll(".", "%2E")}`,
@@ -23,18 +37,32 @@ export const encodeColumnFilters = (
     .join(",");
 };
 
+/**
+ * The default decoder of Tanstack Table's `columnFilters`.
+ *
+ * @param value - The encoded query parameter value to decode.
+ * @param options
+ * @param options.defaultValue
+ * - If you set [`defaultValues`](https://github.com/taro-28/tanstack-table-search-params?tab=readme-ov-file#custom-default-value) in `useTableSearchParams`,
+ * you should set the same value.
+ *
+ * @returns The decoded value.
+ */
 export const decodeColumnFilters = (
-  queryValue: Query[string],
-  defaultValue: State["columnFilters"],
-): State["columnFilters"] => {
-  if (typeof queryValue !== "string") return defaultValue;
-  if (queryValue === "") return defaultValue;
-  if (queryValue === noneStringForCustomDefaultValue) {
+  value: Query[string],
+  options?: {
+    defaultValue?: TanstackTableState["columnFilters"];
+  },
+): TanstackTableState["columnFilters"] | undefined => {
+  const defaultValue = options?.defaultValue;
+  if (typeof value !== "string") return defaultValue;
+  if (value === "") return defaultValue;
+  if (value === noneStringForCustomDefaultValue) {
     return [];
   }
 
   try {
-    return queryValue
+    return value
       .split(",")
       .map((item) => {
         const [id, stringValue] = item.split(".");

--- a/packages/tanstack-table-search-params/src/encoder-decoder/columnOrder.test.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/columnOrder.test.ts
@@ -3,11 +3,11 @@ import { defaultDefaultColumnOrder } from "../useColumnOrder";
 import { decodeColumnOrder, encodeColumnOrder } from "./columnOrder";
 import { noneStringForCustomDefaultValue } from "./noneStringForCustomDefaultValue";
 
-const customDefaultValue = ["custom"];
-
 type DefaultValue = NonNullable<
   NonNullable<Parameters<typeof encodeColumnOrder>[1]>["defaultValue"]
 >;
+
+const customDefaultValue = ["custom"];
 
 describe("columnOrder", () => {
   describe("encode", () =>
@@ -125,7 +125,7 @@ describe("columnOrder", () => {
     ])("default value: $defaultValue", (...defaultValue) =>
       test.each<{
         name: string;
-        stateValue: DefaultValue;
+        stateValue: Parameters<typeof encodeColumnOrder>[0];
       }>([
         {
           name: "default value",

--- a/packages/tanstack-table-search-params/src/encoder-decoder/columnOrder.test.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/columnOrder.test.ts
@@ -5,9 +5,13 @@ import { noneStringForCustomDefaultValue } from "./noneStringForCustomDefaultVal
 
 const customDefaultValue = ["custom"];
 
+type DefaultValue = NonNullable<
+  NonNullable<Parameters<typeof encodeColumnOrder>[1]>["defaultValue"]
+>;
+
 describe("columnOrder", () => {
   describe("encode", () =>
-    describe.each<Parameters<typeof encodeColumnOrder>[1]>([
+    describe.each<DefaultValue>([
       defaultDefaultColumnOrder,
       customDefaultValue,
     ])("default value: %defaultValue", (...defaultValue) =>
@@ -51,7 +55,7 @@ describe("columnOrder", () => {
           want: "foo,bar%2Cbaz",
         },
       ])("$name", ({ stateValue, want }) =>
-        expect(encodeColumnOrder(stateValue, defaultValue)).toEqual(want),
+        expect(encodeColumnOrder(stateValue, { defaultValue })).toEqual(want),
       ),
     ));
 
@@ -66,7 +70,7 @@ describe("columnOrder", () => {
         }>([
           {
             name: "default value",
-            queryValue: encodeColumnOrder(defaultValue, defaultValue),
+            queryValue: encodeColumnOrder(defaultValue, { defaultValue }),
             want: defaultValue,
           },
           {
@@ -110,18 +114,18 @@ describe("columnOrder", () => {
             want: defaultValue,
           },
         ])("$name", ({ queryValue, want }) =>
-          expect(decodeColumnOrder(queryValue, defaultValue)).toEqual(want),
+          expect(decodeColumnOrder(queryValue, { defaultValue })).toEqual(want),
         ),
     ));
 
   describe("encode and decode", () =>
-    describe.each<Parameters<typeof encodeColumnOrder>[1]>([
+    describe.each<DefaultValue>([
       defaultDefaultColumnOrder,
       customDefaultValue,
     ])("default value: $defaultValue", (...defaultValue) =>
       test.each<{
         name: string;
-        stateValue: Parameters<typeof encodeColumnOrder>[1];
+        stateValue: DefaultValue;
       }>([
         {
           name: "default value",
@@ -149,10 +153,9 @@ describe("columnOrder", () => {
         },
       ])("$name", ({ stateValue }) => {
         expect(
-          decodeColumnOrder(
-            encodeColumnOrder(stateValue, defaultValue),
+          decodeColumnOrder(encodeColumnOrder(stateValue, { defaultValue }), {
             defaultValue,
-          ),
+          }),
         ).toEqual(stateValue);
       }),
     ));

--- a/packages/tanstack-table-search-params/src/encoder-decoder/columnOrder.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/columnOrder.ts
@@ -1,29 +1,55 @@
-import type { State } from "..";
+import type { State as TanstackTableState } from "..";
 import type { Query } from "../types";
 import { noneStringForCustomDefaultValue } from "./noneStringForCustomDefaultValue";
 
+/**
+ * The default encoder of Tanstack Table's `columnOrder`.
+ *
+ * @param value - The value to encode.
+ * @param options
+ * @param options.defaultValue
+ * - If you set [`defaultValues`](https://github.com/taro-28/tanstack-table-search-params?tab=readme-ov-file#custom-default-value) in `useTableSearchParams`,
+ * you should set the same value.
+ *
+ * @returns The encoded query parameter value.
+ */
 export const encodeColumnOrder = (
-  stateValue: State["columnOrder"],
-  defaultValue: State["columnOrder"],
+  value: TanstackTableState["columnOrder"],
+  options?: {
+    defaultValue?: TanstackTableState["columnOrder"];
+  },
 ): Query[string] => {
-  if (JSON.stringify(stateValue) === JSON.stringify(defaultValue)) {
+  const defaultValue = options?.defaultValue;
+  if (JSON.stringify(value) === JSON.stringify(defaultValue)) {
     return undefined;
   }
 
   // return encoded empty string if stateValue is empty with custom default value
-  if (stateValue.length === 0) {
+  if (value.length === 0) {
     return noneStringForCustomDefaultValue;
   }
 
-  return stateValue
-    .map((v) => v.replaceAll(",", encodeURIComponent(",")))
-    .join(",");
+  return value.map((v) => v.replaceAll(",", encodeURIComponent(","))).join(",");
 };
 
+/**
+ * The default decoder of Tanstack Table's `columnOrder`.
+ *
+ * @param queryValue - The encoded query parameter value to decode.
+ * @param options
+ * @param options.defaultValue
+ * - If you set [`defaultValues`](https://github.com/taro-28/tanstack-table-search-params?tab=readme-ov-file#custom-default-value) in `useTableSearchParams`,
+ * you should set the same value.
+ *
+ * @returns The decoded value.
+ */
 export const decodeColumnOrder = (
   queryValue: Query[string],
-  defaultValue: State["columnOrder"],
-): State["columnOrder"] => {
+  options?: {
+    defaultValue?: TanstackTableState["columnOrder"];
+  },
+): TanstackTableState["columnOrder"] | undefined => {
+  const defaultValue = options?.defaultValue;
   if (typeof queryValue !== "string") return defaultValue;
   if (queryValue === "") return defaultValue;
   if (queryValue === noneStringForCustomDefaultValue) {

--- a/packages/tanstack-table-search-params/src/encoder-decoder/globalFilter.test.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/globalFilter.test.ts
@@ -12,7 +12,9 @@ describe("globalFilter", () => {
   describe("encode", () =>
     describe.each<{
       name: string;
-      defaultValue: Parameters<typeof encodeGlobalFilter>[1];
+      defaultValue: NonNullable<
+        Parameters<typeof encodeGlobalFilter>[1]
+      >["defaultValue"];
     }>([
       {
         name: "default default value",
@@ -57,14 +59,16 @@ describe("globalFilter", () => {
           want: defaultValue,
         },
       ])("$name", ({ stateValue, want }) =>
-        expect(encodeGlobalFilter(stateValue, defaultValue)).toEqual(want),
+        expect(encodeGlobalFilter(stateValue, { defaultValue })).toEqual(want),
       ),
     ));
 
   describe("decode", () =>
     describe.each<{
       name: string;
-      defaultValue: Parameters<typeof decodeGlobalFilter>[1];
+      defaultValue: NonNullable<
+        Parameters<typeof decodeGlobalFilter>[1]
+      >["defaultValue"];
     }>([
       {
         name: "default default value",
@@ -114,14 +118,16 @@ describe("globalFilter", () => {
           want: defaultValue,
         },
       ])("$name", ({ queryValue, want }) =>
-        expect(decodeGlobalFilter(queryValue, defaultValue)).toBe(want),
+        expect(decodeGlobalFilter(queryValue, { defaultValue })).toBe(want),
       ),
     ));
 
   describe("encode and decode", () =>
     describe.each<{
       name: string;
-      defaultValue: Parameters<typeof encodeGlobalFilter>[1];
+      defaultValue: NonNullable<
+        Parameters<typeof encodeGlobalFilter>[1]
+      >["defaultValue"];
     }>([
       {
         name: "default default value",
@@ -160,8 +166,8 @@ describe("globalFilter", () => {
       ])("$name", ({ globalFilter, wantDecoded }) =>
         expect(
           decodeGlobalFilter(
-            encodeGlobalFilter(globalFilter, defaultValue),
-            defaultValue,
+            encodeGlobalFilter(globalFilter, { defaultValue }),
+            { defaultValue },
           ),
         ).toBe(wantDecoded ?? globalFilter),
       ),

--- a/packages/tanstack-table-search-params/src/encoder-decoder/globalFilter.test.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/globalFilter.test.ts
@@ -13,8 +13,8 @@ describe("globalFilter", () => {
     describe.each<{
       name: string;
       defaultValue: NonNullable<
-        Parameters<typeof encodeGlobalFilter>[1]
-      >["defaultValue"];
+        NonNullable<Parameters<typeof encodeGlobalFilter>[1]>["defaultValue"]
+      >;
     }>([
       {
         name: "default default value",
@@ -67,8 +67,8 @@ describe("globalFilter", () => {
     describe.each<{
       name: string;
       defaultValue: NonNullable<
-        Parameters<typeof decodeGlobalFilter>[1]
-      >["defaultValue"];
+        NonNullable<Parameters<typeof decodeGlobalFilter>[1]>["defaultValue"]
+      >;
     }>([
       {
         name: "default default value",
@@ -126,8 +126,8 @@ describe("globalFilter", () => {
     describe.each<{
       name: string;
       defaultValue: NonNullable<
-        Parameters<typeof encodeGlobalFilter>[1]
-      >["defaultValue"];
+        NonNullable<Parameters<typeof encodeGlobalFilter>[1]>["defaultValue"]
+      >;
     }>([
       {
         name: "default default value",

--- a/packages/tanstack-table-search-params/src/encoder-decoder/globalFilter.test.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/globalFilter.test.ts
@@ -6,16 +6,15 @@ import {
   encodedEmptyStringForGlobalFilterCustomDefaultValue,
 } from "./globalFilter";
 
+type DefaultValue = NonNullable<
+  NonNullable<Parameters<typeof encodeGlobalFilter>[1]>["defaultValue"]
+>;
+
 const customDefaultValue = "default";
 
 describe("globalFilter", () => {
   describe("encode", () =>
-    describe.each<{
-      name: string;
-      defaultValue: NonNullable<
-        NonNullable<Parameters<typeof encodeGlobalFilter>[1]>["defaultValue"]
-      >;
-    }>([
+    describe.each<{ name: string; defaultValue: DefaultValue }>([
       {
         name: "default default value",
         defaultValue: defaultDefaultGlobalFilter,
@@ -64,12 +63,7 @@ describe("globalFilter", () => {
     ));
 
   describe("decode", () =>
-    describe.each<{
-      name: string;
-      defaultValue: NonNullable<
-        NonNullable<Parameters<typeof decodeGlobalFilter>[1]>["defaultValue"]
-      >;
-    }>([
+    describe.each<{ name: string; defaultValue: DefaultValue }>([
       {
         name: "default default value",
         defaultValue: defaultDefaultGlobalFilter,
@@ -123,12 +117,7 @@ describe("globalFilter", () => {
     ));
 
   describe("encode and decode", () =>
-    describe.each<{
-      name: string;
-      defaultValue: NonNullable<
-        NonNullable<Parameters<typeof encodeGlobalFilter>[1]>["defaultValue"]
-      >;
-    }>([
+    describe.each<{ name: string; defaultValue: DefaultValue }>([
       {
         name: "default default value",
         defaultValue: defaultDefaultGlobalFilter,

--- a/packages/tanstack-table-search-params/src/encoder-decoder/globalFilter.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/globalFilter.ts
@@ -18,7 +18,7 @@ export const encodedEmptyStringForGlobalFilterCustomDefaultValue =
 export const encodeGlobalFilter = (
   value: TanstackTableState["globalFilter"] | undefined,
   options?: {
-    defaultValue: TanstackTableState["globalFilter"];
+    defaultValue?: TanstackTableState["globalFilter"];
   },
 ): Query[string] => {
   const defaultValue = options?.defaultValue;
@@ -50,7 +50,7 @@ export const encodeGlobalFilter = (
 export const decodeGlobalFilter = (
   value: Query[string],
   options?: {
-    defaultValue: TanstackTableState["globalFilter"];
+    defaultValue?: TanstackTableState["globalFilter"];
   },
 ): TanstackTableState["globalFilter"] | undefined => {
   const defaultValue = options?.defaultValue;

--- a/packages/tanstack-table-search-params/src/encoder-decoder/globalFilter.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/globalFilter.ts
@@ -1,38 +1,66 @@
-import type { State } from "..";
+import type { State as TanstackTableState } from "..";
 import type { Query } from "../types";
 
 export const encodedEmptyStringForGlobalFilterCustomDefaultValue =
   encodeURIComponent(JSON.stringify(""));
 
+/**
+ * The default encoder of Tanstack Table's `globalFilter`.
+ *
+ * @param value - The value to encode.
+ * @param options
+ * @param options.defaultValue
+ * - If you set [`defaultValues`](https://github.com/taro-28/tanstack-table-search-params?tab=readme-ov-file#custom-default-value) in `useTableSearchParams`,
+ * you should set the same value.
+ *
+ * @returns The encoded query parameter value.
+ */
 export const encodeGlobalFilter = (
-  stateValue: State["globalFilter"],
-  defaultValue: State["globalFilter"],
+  value: TanstackTableState["globalFilter"] | undefined,
+  options?: {
+    defaultValue: TanstackTableState["globalFilter"];
+  },
 ): Query[string] => {
-  if (stateValue === defaultValue) {
+  const defaultValue = options?.defaultValue;
+  if (value === defaultValue) {
     return undefined;
   }
-  if (typeof stateValue !== "string") {
+  if (typeof value !== "string") {
     return defaultValue;
   }
 
   // return encoded empty string if stateValue is empty with custom default value
-  if (stateValue === "") {
+  if (value === "") {
     return encodedEmptyStringForGlobalFilterCustomDefaultValue;
   }
-  return stateValue;
+  return value;
 };
 
+/**
+ * The default decoder of Tanstack Table's `globalFilter`.
+ *
+ * @param value - The encoded query parameter value to decode.
+ * @param options
+ * @param options.defaultValue
+ * - If you set [`defaultValues`](https://github.com/taro-28/tanstack-table-search-params?tab=readme-ov-file#custom-default-value) in `useTableSearchParams`,
+ * you should set the same value.
+ *
+ * @returns The decoded value.
+ */
 export const decodeGlobalFilter = (
-  queryValue: Query[string],
-  defaultValue: State["globalFilter"],
-) => {
-  if (typeof queryValue !== "string") {
+  value: Query[string],
+  options?: {
+    defaultValue: TanstackTableState["globalFilter"];
+  },
+): TanstackTableState["globalFilter"] | undefined => {
+  const defaultValue = options?.defaultValue;
+  if (typeof value !== "string") {
     return defaultValue;
   }
-  if (queryValue === encodedEmptyStringForGlobalFilterCustomDefaultValue) {
+  if (value === encodedEmptyStringForGlobalFilterCustomDefaultValue) {
     return defaultValue === ""
       ? encodedEmptyStringForGlobalFilterCustomDefaultValue
       : "";
   }
-  return queryValue;
+  return value;
 };

--- a/packages/tanstack-table-search-params/src/encoder-decoder/index.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/index.ts
@@ -1,0 +1,2 @@
+// biome-ignore lint/performance/noBarrelFile:
+export { decodeGlobalFilter, encodeGlobalFilter } from "./globalFilter";

--- a/packages/tanstack-table-search-params/src/encoder-decoder/index.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/index.ts
@@ -1,3 +1,4 @@
 // biome-ignore lint/performance/noBarrelFile:
-export { decodeGlobalFilter, encodeGlobalFilter } from "./globalFilter";
-export { decodeSorting, encodeSorting } from "./sorting";
+export { encodeGlobalFilter, decodeGlobalFilter } from "./globalFilter";
+export { encodeSorting, decodeSorting } from "./sorting";
+export { encodePagination, decodePagination } from "./pagination";

--- a/packages/tanstack-table-search-params/src/encoder-decoder/index.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/index.ts
@@ -3,3 +3,4 @@ export { encodeGlobalFilter, decodeGlobalFilter } from "./globalFilter";
 export { encodeSorting, decodeSorting } from "./sorting";
 export { encodePagination, decodePagination } from "./pagination";
 export { encodeColumnFilters, decodeColumnFilters } from "./columnFilters";
+export { encodeColumnOrder, decodeColumnOrder } from "./columnOrder";

--- a/packages/tanstack-table-search-params/src/encoder-decoder/index.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/index.ts
@@ -2,3 +2,4 @@
 export { encodeGlobalFilter, decodeGlobalFilter } from "./globalFilter";
 export { encodeSorting, decodeSorting } from "./sorting";
 export { encodePagination, decodePagination } from "./pagination";
+export { encodeColumnFilters, decodeColumnFilters } from "./columnFilters";

--- a/packages/tanstack-table-search-params/src/encoder-decoder/index.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/index.ts
@@ -1,2 +1,3 @@
 // biome-ignore lint/performance/noBarrelFile:
 export { decodeGlobalFilter, encodeGlobalFilter } from "./globalFilter";
+export { decodeSorting, encodeSorting } from "./sorting";

--- a/packages/tanstack-table-search-params/src/encoder-decoder/pagination.test.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/pagination.test.ts
@@ -11,7 +11,9 @@ describe("pagination", () => {
   describe("encode", () =>
     describe.each<{
       name: string;
-      defaultValue: Parameters<typeof encodePagination>[1];
+      defaultValue: NonNullable<
+        NonNullable<Parameters<typeof encodePagination>[1]>["defaultValue"]
+      >;
     }>([
       {
         name: "default default value",
@@ -75,14 +77,16 @@ describe("pagination", () => {
           want: { pageIndex: "3", pageSize: "0" },
         },
       ])("$name", ({ pagination, want }) =>
-        expect(encodePagination(pagination, defaultValue)).toEqual(want),
+        expect(encodePagination(pagination, { defaultValue })).toEqual(want),
       ),
     ));
 
   describe("decode", () =>
     describe.each<{
       name: string;
-      defaultValue: Parameters<typeof decodePagination>[1];
+      defaultValue: NonNullable<
+        NonNullable<Parameters<typeof decodePagination>[1]>["defaultValue"]
+      >;
     }>([
       {
         name: "default default value",
@@ -100,7 +104,7 @@ describe("pagination", () => {
       }>([
         {
           name: "default pageIndex and pageSize",
-          queryValues: encodePagination(defaultValue, defaultValue),
+          queryValues: encodePagination(defaultValue, { defaultValue }),
           want: defaultValue,
         },
         {
@@ -169,14 +173,16 @@ describe("pagination", () => {
           want: { pageIndex: 1, pageSize: 0 },
         },
       ])("$name", ({ queryValues, want }) =>
-        expect(decodePagination(queryValues, defaultValue)).toEqual(want),
+        expect(decodePagination(queryValues, { defaultValue })).toEqual(want),
       ),
     ));
 
   describe("encode and decode", () =>
     describe.each<{
       name: string;
-      defaultValue: Parameters<typeof encodePagination>[1];
+      defaultValue: NonNullable<
+        NonNullable<Parameters<typeof encodePagination>[1]>["defaultValue"]
+      >;
     }>([
       {
         name: "default default value",
@@ -205,10 +211,9 @@ describe("pagination", () => {
         },
       ])("$name", ({ pagination }) =>
         expect(
-          decodePagination(
-            encodePagination(pagination, defaultValue),
+          decodePagination(encodePagination(pagination, { defaultValue }), {
             defaultValue,
-          ),
+          }),
         ).toEqual(pagination),
       ),
     ));

--- a/packages/tanstack-table-search-params/src/encoder-decoder/pagination.test.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/pagination.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, test } from "vitest";
 import { defaultDefaultPagination } from "../usePagination";
 import { decodePagination, encodePagination } from "./pagination";
 
+type DefaultValue = NonNullable<
+  NonNullable<Parameters<typeof encodePagination>[1]>["defaultValue"]
+>;
+
 const customDefaultValue = {
   pageIndex: 9,
   pageSize: 99,
@@ -9,12 +13,7 @@ const customDefaultValue = {
 
 describe("pagination", () => {
   describe("encode", () =>
-    describe.each<{
-      name: string;
-      defaultValue: NonNullable<
-        NonNullable<Parameters<typeof encodePagination>[1]>["defaultValue"]
-      >;
-    }>([
+    describe.each<{ name: string; defaultValue: DefaultValue }>([
       {
         name: "default default value",
         defaultValue: defaultDefaultPagination,
@@ -82,12 +81,7 @@ describe("pagination", () => {
     ));
 
   describe("decode", () =>
-    describe.each<{
-      name: string;
-      defaultValue: NonNullable<
-        NonNullable<Parameters<typeof decodePagination>[1]>["defaultValue"]
-      >;
-    }>([
+    describe.each<{ name: string; defaultValue: DefaultValue }>([
       {
         name: "default default value",
         defaultValue: defaultDefaultPagination,
@@ -178,12 +172,7 @@ describe("pagination", () => {
     ));
 
   describe("encode and decode", () =>
-    describe.each<{
-      name: string;
-      defaultValue: NonNullable<
-        NonNullable<Parameters<typeof encodePagination>[1]>["defaultValue"]
-      >;
-    }>([
+    describe.each<{ name: string; defaultValue: DefaultValue }>([
       {
         name: "default default value",
         defaultValue: defaultDefaultPagination,

--- a/packages/tanstack-table-search-params/src/encoder-decoder/pagination.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/pagination.ts
@@ -13,7 +13,7 @@ import type { Query } from "../types";
  * @returns The encoded query parameter value.
  */
 export const encodePagination = (
-  stateValue: TanstackTableState["pagination"],
+  value: TanstackTableState["pagination"],
   options?: {
     defaultValue?: TanstackTableState["pagination"];
   },
@@ -24,20 +24,20 @@ export const encodePagination = (
   const defaultValue = options?.defaultValue;
   return {
     pageIndex:
-      stateValue.pageIndex === defaultValue?.pageIndex
+      value.pageIndex === defaultValue?.pageIndex
         ? undefined
-        : (stateValue.pageIndex + 1).toString(),
+        : (value.pageIndex + 1).toString(),
     pageSize:
-      stateValue.pageSize === defaultValue?.pageSize
+      value.pageSize === defaultValue?.pageSize
         ? undefined
-        : stateValue.pageSize.toString(),
+        : value.pageSize.toString(),
   };
 };
 
 /**
  * The default decoder of Tanstack Table's `pagination`.
  *
- * @param queryValues - The encoded query parameter value to decode.
+ * @param value - The encoded query parameter value to decode.
  * @param options
  * @param options.defaultValue
  * - If you set [`defaultValues`](https://github.com/taro-28/tanstack-table-search-params?tab=readme-ov-file#custom-default-value) in `useTableSearchParams`,
@@ -46,7 +46,7 @@ export const encodePagination = (
  * @returns The decoded value.
  */
 export const decodePagination = (
-  queryValues: {
+  value: {
     pageIndex: Query[string];
     pageSize: Query[string];
   },
@@ -57,16 +57,16 @@ export const decodePagination = (
   | TanstackTableState["pagination"]
   | { pageIndex: number | undefined; pageSize: number | undefined } => {
   const defaultValue = options?.defaultValue;
-  const pageIndex = Number(queryValues.pageIndex);
-  const pageSize = Number(queryValues.pageSize);
+  const pageIndex = Number(value.pageIndex);
+  const pageSize = Number(value.pageSize);
 
   return {
     pageIndex:
-      queryValues.pageIndex === "" || Number.isNaN(pageIndex) || pageIndex < 1
+      value.pageIndex === "" || Number.isNaN(pageIndex) || pageIndex < 1
         ? defaultValue?.pageIndex
         : pageIndex - 1,
     pageSize:
-      queryValues.pageSize === "" || Number.isNaN(pageSize)
+      value.pageSize === "" || Number.isNaN(pageSize)
         ? defaultValue?.pageSize
         : pageSize,
   };

--- a/packages/tanstack-table-search-params/src/encoder-decoder/pagination.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/pagination.ts
@@ -1,41 +1,73 @@
-import type { State } from "..";
+import type { State as TanstackTableState } from "..";
 import type { Query } from "../types";
 
+/**
+ * The default encoder of Tanstack Table's `pagination`.
+ *
+ * @param value - The value to encode.
+ * @param options
+ * @param options.defaultValue
+ * - If you set [`defaultValues`](https://github.com/taro-28/tanstack-table-search-params?tab=readme-ov-file#custom-default-value) in `useTableSearchParams`,
+ * you should set the same value.
+ *
+ * @returns The encoded query parameter value.
+ */
 export const encodePagination = (
-  stateValue: State["pagination"],
-  defaultValue: State["pagination"],
+  stateValue: TanstackTableState["pagination"],
+  options?: {
+    defaultValue?: TanstackTableState["pagination"];
+  },
 ): {
   pageIndex: Query[string];
   pageSize: Query[string];
-} => ({
-  pageIndex:
-    stateValue.pageIndex === defaultValue.pageIndex
-      ? undefined
-      : (stateValue.pageIndex + 1).toString(),
-  pageSize:
-    stateValue.pageSize === defaultValue.pageSize
-      ? undefined
-      : stateValue.pageSize.toString(),
-});
+} => {
+  const defaultValue = options?.defaultValue;
+  return {
+    pageIndex:
+      stateValue.pageIndex === defaultValue?.pageIndex
+        ? undefined
+        : (stateValue.pageIndex + 1).toString(),
+    pageSize:
+      stateValue.pageSize === defaultValue?.pageSize
+        ? undefined
+        : stateValue.pageSize.toString(),
+  };
+};
 
+/**
+ * The default decoder of Tanstack Table's `pagination`.
+ *
+ * @param queryValues - The encoded query parameter value to decode.
+ * @param options
+ * @param options.defaultValue
+ * - If you set [`defaultValues`](https://github.com/taro-28/tanstack-table-search-params?tab=readme-ov-file#custom-default-value) in `useTableSearchParams`,
+ * you should set the same value.
+ *
+ * @returns The decoded value.
+ */
 export const decodePagination = (
   queryValues: {
     pageIndex: Query[string];
     pageSize: Query[string];
   },
-  defaultValue: State["pagination"],
-) => {
+  options?: {
+    defaultValue?: TanstackTableState["pagination"];
+  },
+):
+  | TanstackTableState["pagination"]
+  | { pageIndex: number | undefined; pageSize: number | undefined } => {
+  const defaultValue = options?.defaultValue;
   const pageIndex = Number(queryValues.pageIndex);
   const pageSize = Number(queryValues.pageSize);
 
   return {
     pageIndex:
       queryValues.pageIndex === "" || Number.isNaN(pageIndex) || pageIndex < 1
-        ? defaultValue.pageIndex
+        ? defaultValue?.pageIndex
         : pageIndex - 1,
     pageSize:
       queryValues.pageSize === "" || Number.isNaN(pageSize)
-        ? defaultValue.pageSize
+        ? defaultValue?.pageSize
         : pageSize,
   };
 };

--- a/packages/tanstack-table-search-params/src/encoder-decoder/sorting.test.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/sorting.test.ts
@@ -3,6 +3,10 @@ import { defaultDefaultSorting } from "../useSorting";
 import { noneStringForCustomDefaultValue } from "./noneStringForCustomDefaultValue";
 import { decodeSorting, encodeSorting } from "./sorting";
 
+type DefaultValue = NonNullable<
+  NonNullable<Parameters<typeof encodeSorting>[1]>["defaultValue"]
+>;
+
 const customDefaultValue = [
   {
     id: "custom",
@@ -12,12 +16,7 @@ const customDefaultValue = [
 
 describe("sorting", () => {
   describe("encode", () =>
-    describe.each<{
-      name: string;
-      defaultValue: NonNullable<
-        NonNullable<Parameters<typeof encodeSorting>[1]>["defaultValue"]
-      >;
-    }>([
+    describe.each<{ name: string; defaultValue: DefaultValue }>([
       {
         name: "default default value",
         defaultValue: defaultDefaultSorting,
@@ -65,12 +64,7 @@ describe("sorting", () => {
     ));
 
   describe("decode", () =>
-    describe.each<{
-      name: string;
-      defaultValue: NonNullable<
-        NonNullable<Parameters<typeof decodeSorting>[1]>["defaultValue"]
-      >;
-    }>([
+    describe.each<{ name: string; defaultValue: DefaultValue }>([
       {
         name: "default default value",
         defaultValue: defaultDefaultSorting,
@@ -131,12 +125,7 @@ describe("sorting", () => {
     ));
 
   describe("encode and decode", () =>
-    describe.each<{
-      name: string;
-      defaultValue: NonNullable<
-        NonNullable<Parameters<typeof encodeSorting>[1]>["defaultValue"]
-      >;
-    }>([
+    describe.each<{ name: string; defaultValue: DefaultValue }>([
       {
         name: "default default value",
         defaultValue: defaultDefaultSorting,

--- a/packages/tanstack-table-search-params/src/encoder-decoder/sorting.test.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/sorting.test.ts
@@ -15,8 +15,8 @@ describe("sorting", () => {
     describe.each<{
       name: string;
       defaultValue: NonNullable<
-        Parameters<typeof encodeSorting>[1]
-      >["defaultValue"];
+        NonNullable<Parameters<typeof encodeSorting>[1]>["defaultValue"]
+      >;
     }>([
       {
         name: "default default value",
@@ -68,8 +68,8 @@ describe("sorting", () => {
     describe.each<{
       name: string;
       defaultValue: NonNullable<
-        Parameters<typeof decodeSorting>[1]
-      >["defaultValue"];
+        NonNullable<Parameters<typeof decodeSorting>[1]>["defaultValue"]
+      >;
     }>([
       {
         name: "default default value",
@@ -134,8 +134,8 @@ describe("sorting", () => {
     describe.each<{
       name: string;
       defaultValue: NonNullable<
-        Parameters<typeof encodeSorting>[1]
-      >["defaultValue"];
+        NonNullable<Parameters<typeof encodeSorting>[1]>["defaultValue"]
+      >;
     }>([
       {
         name: "default default value",

--- a/packages/tanstack-table-search-params/src/encoder-decoder/sorting.test.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/sorting.test.ts
@@ -14,7 +14,9 @@ describe("sorting", () => {
   describe("encode", () =>
     describe.each<{
       name: string;
-      defaultValue: Parameters<typeof encodeSorting>[1];
+      defaultValue: NonNullable<
+        Parameters<typeof encodeSorting>[1]
+      >["defaultValue"];
     }>([
       {
         name: "default default value",
@@ -58,14 +60,16 @@ describe("sorting", () => {
           want: "foo.desc,bar.asc",
         },
       ])("$name", ({ stateValue, want }) =>
-        expect(encodeSorting(stateValue, defaultValue)).toEqual(want),
+        expect(encodeSorting(stateValue, { defaultValue })).toEqual(want),
       ),
     ));
 
   describe("decode", () =>
     describe.each<{
       name: string;
-      defaultValue: Parameters<typeof decodeSorting>[1];
+      defaultValue: NonNullable<
+        Parameters<typeof decodeSorting>[1]
+      >["defaultValue"];
     }>([
       {
         name: "default default value",
@@ -83,7 +87,7 @@ describe("sorting", () => {
       }>([
         {
           name: "default value",
-          queryValue: encodeSorting(defaultValue, defaultValue),
+          queryValue: encodeSorting(defaultValue, { defaultValue }),
           want: defaultValue,
         },
         {
@@ -122,14 +126,16 @@ describe("sorting", () => {
           want: defaultValue,
         },
       ])("$name", ({ queryValue, want }) =>
-        expect(decodeSorting(queryValue, defaultValue)).toEqual(want),
+        expect(decodeSorting(queryValue, { defaultValue })).toEqual(want),
       ),
     ));
 
   describe("encode and decode", () =>
     describe.each<{
       name: string;
-      defaultValue: Parameters<typeof encodeSorting>[1];
+      defaultValue: NonNullable<
+        Parameters<typeof encodeSorting>[1]
+      >["defaultValue"];
     }>([
       {
         name: "default default value",
@@ -165,7 +171,9 @@ describe("sorting", () => {
         },
       ])("$name", ({ stateValue }) => {
         expect(
-          decodeSorting(encodeSorting(stateValue, defaultValue), defaultValue),
+          decodeSorting(encodeSorting(stateValue, { defaultValue }), {
+            defaultValue,
+          }),
         ).toEqual(stateValue);
       }),
     ));

--- a/packages/tanstack-table-search-params/src/encoder-decoder/sorting.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/sorting.ts
@@ -2,36 +2,64 @@ import type { State } from "..";
 import type { Query } from "../types";
 import { noneStringForCustomDefaultValue } from "./noneStringForCustomDefaultValue";
 
+/**
+ * The default encoder of Tanstack Table's `sorting`.
+ *
+ * @param value - The value to encode.
+ * @param options
+ * @param options.defaultValue
+ * - If you set [`defaultValues`](https://github.com/taro-28/tanstack-table-search-params?tab=readme-ov-file#custom-default-value) in `useTableSearchParams`,
+ * you should set the same value.
+ *
+ * @returns The encoded query parameter value.
+ */
 export const encodeSorting = (
-  stateValue: State["sorting"],
-  defaultValue: State["sorting"],
+  value: State["sorting"],
+  options?: {
+    defaultValue: State["sorting"];
+  },
 ): Query[string] => {
-  if (JSON.stringify(stateValue) === JSON.stringify(defaultValue)) {
+  const defaultValue = options?.defaultValue;
+  if (JSON.stringify(value) === JSON.stringify(defaultValue)) {
     return undefined;
   }
 
   // return encoded empty string if stateValue is empty with custom default value
-  if (stateValue.length === 0) {
+  if (value.length === 0) {
     return noneStringForCustomDefaultValue;
   }
 
-  return stateValue
+  return value
     .map(({ id, desc }) => `${id}.${desc ? "desc" : "asc"}`)
     .join(",");
 };
 
+/**
+ * The default decoder of Tanstack Table's `sorting`.
+ *
+ * @param value - The encoded query parameter value to decode.
+ * @param options
+ * @param options.defaultValue
+ * - If you set [`defaultValues`](https://github.com/taro-28/tanstack-table-search-params?tab=readme-ov-file#custom-default-value) in `useTableSearchParams`,
+ * you should set the same value.
+ *
+ * @returns The decoded value.
+ */
 export const decodeSorting = (
-  queryValue: Query[string],
-  defaultValue: State["sorting"],
-) => {
-  if (typeof queryValue !== "string") return defaultValue;
-  if (queryValue === "") return defaultValue;
-  if (queryValue === noneStringForCustomDefaultValue) {
+  value: Query[string],
+  options?: {
+    defaultValue: State["sorting"];
+  },
+): State["sorting"] | undefined => {
+  const defaultValue = options?.defaultValue;
+  if (typeof value !== "string") return defaultValue;
+  if (value === "") return defaultValue;
+  if (value === noneStringForCustomDefaultValue) {
     return [];
   }
 
   try {
-    return queryValue.split(",").map((sort) => {
+    return value.split(",").map((sort) => {
       const [id, order] = sort.split(".");
       if (!id) throw new Error("Invalid sorting");
       if (order !== "asc" && order !== "desc") {

--- a/packages/tanstack-table-search-params/src/encoder-decoder/sorting.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/sorting.ts
@@ -16,7 +16,7 @@ import { noneStringForCustomDefaultValue } from "./noneStringForCustomDefaultVal
 export const encodeSorting = (
   value: State["sorting"],
   options?: {
-    defaultValue: State["sorting"];
+    defaultValue?: State["sorting"];
   },
 ): Query[string] => {
   const defaultValue = options?.defaultValue;
@@ -48,7 +48,7 @@ export const encodeSorting = (
 export const decodeSorting = (
   value: Query[string],
   options?: {
-    defaultValue: State["sorting"];
+    defaultValue?: State["sorting"];
   },
 ): State["sorting"] | undefined => {
   const defaultValue = options?.defaultValue;

--- a/packages/tanstack-table-search-params/src/useColumnFilters.ts
+++ b/packages/tanstack-table-search-params/src/useColumnFilters.ts
@@ -35,10 +35,9 @@ export const useColumnFilters = ({ router, options }: Props): Returns => {
 
   const uncustomisedColumnFilters = useMemo(
     () =>
-      decodeColumnFilters(
-        router.query[paramName],
-        JSON.parse(stringDefaultColumnFilters),
-      ),
+      decodeColumnFilters(router.query[paramName], {
+        defaultValue: JSON.parse(stringDefaultColumnFilters),
+      }),
     [router.query[paramName], paramName, stringDefaultColumnFilters],
   );
 
@@ -66,10 +65,9 @@ export const useColumnFilters = ({ router, options }: Props): Returns => {
         options?.encoder
           ? options.encoder(columnFilters)
           : {
-              [paramName]: encodeColumnFilters(
-                columnFilters,
-                JSON.parse(stringDefaultColumnFilters),
-              ),
+              [paramName]: encodeColumnFilters(columnFilters, {
+                defaultValue: JSON.parse(stringDefaultColumnFilters),
+              }),
             };
       await updateQuery({
         oldQuery: encoder(_columnFilters),

--- a/packages/tanstack-table-search-params/src/useColumnOrder.ts
+++ b/packages/tanstack-table-search-params/src/useColumnOrder.ts
@@ -35,10 +35,9 @@ export const useColumnOrder = ({ router, options }: Props): Returns => {
 
   const uncustomisedColumnOrder = useMemo(
     () =>
-      decodeColumnOrder(
-        router.query[paramName],
-        JSON.parse(stringDefaultColumnOrder),
-      ),
+      decodeColumnOrder(router.query[paramName], {
+        defaultValue: JSON.parse(stringDefaultColumnOrder),
+      }),
     [router.query[paramName], paramName, stringDefaultColumnOrder],
   );
 
@@ -66,10 +65,9 @@ export const useColumnOrder = ({ router, options }: Props): Returns => {
         options?.encoder
           ? options.encoder(columnOrder)
           : {
-              [paramName]: encodeColumnOrder(
-                columnOrder,
-                JSON.parse(stringDefaultColumnOrder),
-              ),
+              [paramName]: encodeColumnOrder(columnOrder, {
+                defaultValue: JSON.parse(stringDefaultColumnOrder),
+              }),
             };
       await updateQuery({
         oldQuery: encoder(_columnOrder),

--- a/packages/tanstack-table-search-params/src/useGlobalFilter.ts
+++ b/packages/tanstack-table-search-params/src/useGlobalFilter.ts
@@ -34,7 +34,9 @@ export const useGlobalFilter = ({ router, options }: Props): Returns => {
 
   const _globalFilter = options?.decoder
     ? options?.decoder?.(router.query)
-    : decodeGlobalFilter(router.query[paramNames], defaultGlobalFilter);
+    : decodeGlobalFilter(router.query[paramNames], {
+        defaultValue: defaultGlobalFilter,
+      });
 
   const updateGlobalFilterQuery = useCallback(
     async (newGlobalFilter: State["globalFilter"]) => {
@@ -42,10 +44,9 @@ export const useGlobalFilter = ({ router, options }: Props): Returns => {
         options?.encoder
           ? options.encoder(globalFilter)
           : {
-              [paramNames]: encodeGlobalFilter(
-                globalFilter,
-                defaultGlobalFilter,
-              ),
+              [paramNames]: encodeGlobalFilter(globalFilter, {
+                defaultValue: defaultGlobalFilter,
+              }),
             };
       await updateQuery({
         oldQuery: encoder(_globalFilter),

--- a/packages/tanstack-table-search-params/src/usePagination.ts
+++ b/packages/tanstack-table-search-params/src/usePagination.ts
@@ -58,8 +58,10 @@ export const usePagination = ({ router, options }: Props): Returns => {
           pageSize: router.query[paramName.pageSize],
         },
         {
-          pageIndex: defaultPagination.pageIndex,
-          pageSize: defaultPagination.pageSize,
+          defaultValue: {
+            pageIndex: defaultPagination.pageIndex,
+            pageSize: defaultPagination.pageSize,
+          },
         },
       ),
     [
@@ -103,8 +105,10 @@ export const usePagination = ({ router, options }: Props): Returns => {
       const encoder = (pagination: State["pagination"]) => {
         if (options?.encoder) return options.encoder(pagination);
         const encoded = encodePagination(pagination, {
-          pageIndex: defaultPagination.pageIndex,
-          pageSize: defaultPagination.pageSize,
+          defaultValue: {
+            pageIndex: defaultPagination.pageIndex,
+            pageSize: defaultPagination.pageSize,
+          },
         });
         return {
           [paramName.pageIndex]: encoded.pageIndex,

--- a/packages/tanstack-table-search-params/src/useSorting.ts
+++ b/packages/tanstack-table-search-params/src/useSorting.ts
@@ -31,7 +31,9 @@ export const useSorting = ({ router, options }: Props): Returns => {
 
   const uncustomisedSorting = useMemo(
     () =>
-      decodeSorting(router.query[paramName], JSON.parse(stringDefaultSorting)),
+      decodeSorting(router.query[paramName], {
+        defaultValue: JSON.parse(stringDefaultSorting),
+      }),
     [router.query[paramName], paramName, stringDefaultSorting],
   );
 
@@ -59,10 +61,9 @@ export const useSorting = ({ router, options }: Props): Returns => {
         options?.encoder
           ? options.encoder(sorting)
           : {
-              [paramName]: encodeSorting(
-                sorting,
-                JSON.parse(stringDefaultSorting),
-              ),
+              [paramName]: encodeSorting(sorting, {
+                defaultValue: JSON.parse(stringDefaultSorting),
+              }),
             };
       await updateQuery({
         oldQuery: encoder(_sorting),

--- a/packages/tanstack-table-search-params/tsup.config.ts
+++ b/packages/tanstack-table-search-params/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/encoder-decoder/index.ts"],
   target: "esnext",
   format: ["cjs", "esm"],
   clean: true,


### PR DESCRIPTION
### What’s new in this PR

- **Default encoder / decoder are now exported.**  
  You can import them from `tanstack-table-search-params/encoder-decoder`.

- **Use the default encoder when pre-setting URL parameters.**  
  When you need to navigate to a page that contains a table and want to attach query parameters ahead of time, you can now rely on the default encoder.

```tsx
import { encodeSorting } from "tanstack-table-search-params/encoder-decoder";

<Link
  href={{
    pathname: "/some-page-with-table",
    query: {
      sorting: encodeSorting([{ id: "name", desc: true }]),
    },
  }}
>
  foo
</Link>
```