### PR TITLE
support `onStateChange`

### DIFF
--- a/examples/lib/src/components/UserTable.tsx
+++ b/examples/lib/src/components/UserTable.tsx
@@ -7,6 +7,16 @@ const Cell = ({ className, ...props }: JSX.IntrinsicElements["div"]) => (
   <div {...props} className={`table-cell py-1 px-2 text-center ${className}`} />
 );
 
+const Button = (
+  props: Omit<JSX.IntrinsicElements["button"], "type" | "className">,
+) => (
+  <button
+    {...props}
+    type="button"
+    className="border rounded px-2 hover:bg-gray-100"
+  />
+);
+
 type Props = {
   table: Table<User>;
 };
@@ -22,8 +32,7 @@ export const UserTable = ({ table }: Props) => {
             onSearch={(value) => table.setGlobalFilter(value)}
             defaultValue={table.getState().globalFilter ?? ""}
           />
-          <button
-            type="button"
+          <Button
             onClick={() => {
               setIsReversed((prev) => !prev);
               table.setColumnOrder(
@@ -35,10 +44,10 @@ export const UserTable = ({ table }: Props) => {
                       .map((c) => c.id),
               );
             }}
-            className="border rounded px-2"
           >
             {isReversed ? "Reset Order" : "Reverse Order"}
-          </button>
+          </Button>
+          <Button onClick={table.reset}>Reset State</Button>
         </div>
         <div className="table border-2 border-gray-200 rounded-md ">
           <div className="table-header-group bg-slate-200">

--- a/packages/tanstack-table-search-params/src/encoder-decoder/globalFilter.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/globalFilter.ts
@@ -19,7 +19,7 @@ export const defaultDefaultGlobalFilter =
  * @returns The encoded query parameter value.
  */
 export const encodeGlobalFilter = (
-  value: TanstackTableState["globalFilter"] | undefined,
+  value: TanstackTableState["globalFilter"] | undefined = "",
   options?: {
     defaultValue?: TanstackTableState["globalFilter"];
   },

--- a/packages/tanstack-table-search-params/src/tests/columnOrder.test.ts
+++ b/packages/tanstack-table-search-params/src/tests/columnOrder.test.ts
@@ -24,7 +24,7 @@ describe("columnOrder", () => {
       name: "with options: string param name",
       options: {
         paramNames: {
-          columnOrder: "COLUMN_FILTERS",
+          columnOrder: "COLUMN_ORDER",
         },
       },
     },
@@ -114,7 +114,7 @@ describe("columnOrder", () => {
       name: "with options: custom param name, default value, debounce",
       options: {
         paramNames: {
-          columnOrder: "COLUMN_FILTERS",
+          columnOrder: "COLUMN_ORDER",
         },
         defaultValues: {
           columnOrder: ["name", "id"],

--- a/packages/tanstack-table-search-params/src/tests/next-pages-router/onStateChange.test.ts
+++ b/packages/tanstack-table-search-params/src/tests/next-pages-router/onStateChange.test.ts
@@ -1,0 +1,453 @@
+import {
+  getCoreRowModel,
+  type TableState,
+  useReactTable,
+} from "@tanstack/react-table";
+import { act, renderHook } from "@testing-library/react";
+import mockRouter from "next-router-mock";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { type State, useTableSearchParams } from "../..";
+import {
+  defaultDefaultGlobalFilter,
+  encodedEmptyStringForGlobalFilterCustomDefaultValue,
+} from "../../encoder-decoder/globalFilter";
+import { noneStringForCustomDefaultValue } from "../../encoder-decoder/noneStringForCustomDefaultValue";
+import { defaultDefaultPagination } from "../../encoder-decoder/pagination";
+
+const emptyState: TableState = {
+  globalFilter: "",
+  sorting: [],
+  columnFilters: [],
+  columnOrder: [],
+  rowSelection: {},
+  pagination: { pageIndex: 0, pageSize: 10 },
+  columnPinning: { left: [], right: [] },
+  expanded: {},
+  columnSizing: {},
+  grouping: [],
+  columnSizingInfo: {
+    columnSizingStart: [],
+    deltaOffset: null,
+    deltaPercentage: null,
+    isResizingColumn: false,
+    startOffset: null,
+    startSize: null,
+  },
+  rowPinning: { bottom: [], top: [] },
+  columnVisibility: {},
+};
+
+describe("onStateChange", () => {
+  beforeEach(vi.useFakeTimers);
+  afterEach(() => {
+    mockRouter.query = {};
+  });
+  test.each<{
+    name: string;
+    options?: Parameters<typeof useTableSearchParams>[1];
+  }>([
+    { name: "no options" },
+    {
+      name: "with options: string param name",
+      options: {
+        paramNames: {
+          globalFilter: "GLOBAL_FILTER",
+          sorting: "SORTING",
+          columnFilters: "COLUMN_FILTERS",
+          columnOrder: "COLUMN_ORDER",
+          rowSelection: "ROW_SELECTION",
+          pagination: {
+            pageIndex: "PAGE_INDEX",
+            pageSize: "PAGE_SIZE",
+          },
+        },
+      },
+    },
+    {
+      name: "with options: function param name",
+      options: {
+        paramNames: {
+          globalFilter: (key) => `userTable-${key}`,
+          sorting: (key) => `userTable-${key}`,
+          columnFilters: (key) => `userTable-${key}`,
+          columnOrder: (key) => `userTable-${key}`,
+          rowSelection: (key) => `userTable-${key}`,
+          pagination: ({ pageIndex, pageSize }) => ({
+            pageIndex: `userTable-${pageIndex}`,
+            pageSize: `userTable-${pageSize}`,
+          }),
+        },
+      },
+    },
+    {
+      name: "with options: default param name encoder/decoder",
+      options: {
+        encoders: {
+          globalFilter: (globalFilter = "") => ({
+            globalFilter: JSON.stringify(globalFilter),
+          }),
+          sorting: (sorting) => ({
+            sorting: JSON.stringify(sorting),
+          }),
+          columnFilters: (columnFilters) => ({
+            columnFilters: JSON.stringify(columnFilters),
+          }),
+          columnOrder: (columnOrder) => ({
+            columnOrder: JSON.stringify(columnOrder),
+          }),
+          rowSelection: (rowSelection) => ({
+            rowSelection: JSON.stringify(rowSelection),
+          }),
+          pagination: (pagination) => ({
+            pageIndex: JSON.stringify(pagination.pageIndex),
+            pageSize: JSON.stringify(pagination.pageSize),
+          }),
+        },
+        decoders: {
+          globalFilter: (query) =>
+            query["globalFilter"]
+              ? JSON.parse(query["globalFilter"] as string)
+              : (query["globalFilter"] ?? ""),
+          sorting: (query) =>
+            query["sorting"]
+              ? JSON.parse(query["sorting"] as string)
+              : query["sorting"],
+          columnFilters: (query) =>
+            query["columnFilters"]
+              ? JSON.parse(query["columnFilters"] as string)
+              : query["columnFilters"],
+          columnOrder: (query) =>
+            query["columnOrder"]
+              ? JSON.parse(query["columnOrder"] as string)
+              : query["columnOrder"],
+          rowSelection: (query) =>
+            query["rowSelection"]
+              ? JSON.parse(query["rowSelection"] as string)
+              : query["rowSelection"],
+          pagination: (query) => ({
+            pageIndex: query["pageIndex"]
+              ? JSON.parse(query["pageIndex"] as string)
+              : defaultDefaultPagination.pageIndex,
+            pageSize: query["pageSize"]
+              ? JSON.parse(query["pageSize"] as string)
+              : defaultDefaultPagination.pageSize,
+          }),
+        },
+      },
+    },
+    {
+      name: "with options: custom param name encoder/decoder",
+      options: {
+        encoders: {
+          globalFilter: (globalFilter = "") => ({
+            "userTable-globalFilter": JSON.stringify(globalFilter),
+          }),
+          sorting: (sorting) => ({
+            "userTable-sorting": JSON.stringify(sorting),
+          }),
+          columnFilters: (columnFilters) => ({
+            "userTable-columnFilters": JSON.stringify(columnFilters),
+          }),
+          columnOrder: (columnOrder) => ({
+            "userTable-columnOrder": JSON.stringify(columnOrder),
+          }),
+          rowSelection: (rowSelection) => ({
+            "userTable-rowSelection": JSON.stringify(rowSelection),
+          }),
+          pagination: (pagination) => ({
+            "userTable-pageIndex": JSON.stringify(pagination.pageIndex),
+            "userTable-pageSize": JSON.stringify(pagination.pageSize),
+          }),
+        },
+        decoders: {
+          globalFilter: (query) =>
+            query["userTable-globalFilter"]
+              ? JSON.parse(query["userTable-globalFilter"] as string)
+              : (query["userTable-globalFilter"] ?? ""),
+          sorting: (query) =>
+            query["userTable-sorting"]
+              ? JSON.parse(query["userTable-sorting"] as string)
+              : query["userTable-sorting"],
+          columnFilters: (query) =>
+            query["userTable-columnFilters"]
+              ? JSON.parse(query["userTable-columnFilters"] as string)
+              : query["userTable-columnFilters"],
+          columnOrder: (query) =>
+            query["userTable-columnOrder"]
+              ? JSON.parse(query["userTable-columnOrder"] as string)
+              : query["userTable-columnOrder"],
+          rowSelection: (query) =>
+            query["userTable-rowSelection"]
+              ? JSON.parse(query["userTable-rowSelection"] as string)
+              : query["userTable-rowSelection"],
+          pagination: (query) => ({
+            pageIndex: query["userTable-pageIndex"]
+              ? JSON.parse(query["userTable-pageIndex"] as string)
+              : defaultDefaultPagination.pageIndex,
+            pageSize: query["userTable-pageSize"]
+              ? JSON.parse(query["userTable-pageSize"] as string)
+              : defaultDefaultPagination.pageSize,
+          }),
+        },
+      },
+    },
+    {
+      name: "with options: custom number of params encoder/decoder",
+      options: {
+        encoders: {
+          sorting: (sorting) =>
+            Object.fromEntries(
+              sorting.map(({ id, desc }) => [
+                `sorting.${id}`,
+                desc ? "desc" : "asc",
+              ]),
+            ),
+          columnFilters: (columnFilters) =>
+            Object.fromEntries(
+              columnFilters.map(({ id, value }) => [
+                `columnFilters.${id}`,
+                JSON.stringify(value),
+              ]),
+            ),
+          columnOrder: (columnOrder) =>
+            Object.fromEntries(
+              columnOrder.map((value, i) => [
+                `columnOrder.${i}`,
+                JSON.stringify(value),
+              ]),
+            ),
+          rowSelection: (rowSelection) =>
+            Object.fromEntries(
+              Object.keys(rowSelection).map((id) => [
+                `rowSelection.${id}`,
+                "true",
+              ]),
+            ),
+          pagination: (pagination) => ({
+            pagination: JSON.stringify(pagination),
+          }),
+        },
+        decoders: {
+          sorting: (query) =>
+            Object.entries(query)
+              .filter(([key]) => key.startsWith("sorting."))
+              .map(([key, desc]) => ({
+                id: key.replace("sorting.", ""),
+                desc: desc === "desc",
+              })),
+          columnFilters: (query) =>
+            Object.entries(query)
+              .filter(([key]) => key.startsWith("columnFilters."))
+              .map(([key, value]) => ({
+                id: key.replace("columnFilters.", ""),
+                value: JSON.parse(value as string),
+              })),
+          columnOrder: (query) =>
+            Object.entries(query)
+              .filter(([key]) => key.startsWith("columnOrder."))
+              .map(([_, value]) => JSON.parse(value as string)),
+          rowSelection: (query) =>
+            Object.fromEntries(
+              Object.entries(query)
+                .filter(([key]) => key.startsWith("rowSelection."))
+                .map(([key]) => [key.replace("rowSelection.", ""), true]),
+            ),
+          pagination: (query) =>
+            query["pagination"]
+              ? JSON.parse(query["pagination"] as string)
+              : defaultDefaultPagination,
+        },
+      },
+    },
+    {
+      name: "with options: custom default value",
+      options: {
+        defaultValues: {
+          globalFilter: "default",
+          sorting: [{ id: "name", desc: true }],
+          columnFilters: [{ id: "custom", value: "default" }],
+          columnOrder: ["name", "id"],
+          rowSelection: { "1": true },
+          pagination: { pageIndex: 3, pageSize: 25 },
+        },
+      },
+    },
+    {
+      name: "with options: debounce milliseconds",
+      options: { debounceMilliseconds: 1 },
+    },
+    {
+      name: "with options: custom param name, default value",
+      options: {
+        paramNames: {
+          globalFilter: "GLOBAL_FILTER",
+          sorting: "SORTING",
+          columnFilters: "COLUMN_FILTERS",
+          columnOrder: "COLUMN_ORDER",
+          rowSelection: "ROW_SELECTION",
+          pagination: { pageIndex: "PAGE_INDEX", pageSize: "PAGE_SIZE" },
+        },
+        defaultValues: {
+          globalFilter: "default",
+          sorting: [{ id: "name", desc: true }],
+          columnFilters: [{ id: "custom", value: "default" }],
+          columnOrder: ["name", "id"],
+          rowSelection: { "1": true },
+          pagination: { pageIndex: 3, pageSize: 25 },
+        },
+      },
+    },
+  ])("%s", ({ options }) => {
+    const getParamName = (
+      name: Extract<
+        keyof State,
+        | "globalFilter"
+        | "sorting"
+        | "columnFilters"
+        | "columnOrder"
+        | "rowSelection"
+      >,
+    ) => {
+      const paramName = options?.paramNames?.[name];
+      return typeof paramName === "function"
+        ? paramName(name as never)
+        : paramName || name;
+    };
+
+    const globalFilterParamName = getParamName("globalFilter");
+    const sortingParamName = getParamName("sorting");
+    const columnFiltersParamName = getParamName("columnFilters");
+    const columnOrderParamName = getParamName("columnOrder");
+    const rowSelectionParamName = getParamName("rowSelection");
+    const paginationParamName =
+      typeof options?.paramNames?.pagination === "function"
+        ? options.paramNames.pagination({
+            pageIndex: "pageIndex",
+            pageSize: "pageSize",
+          })
+        : (options?.paramNames?.pagination ?? {
+            pageIndex: "pageIndex",
+            pageSize: "pageSize",
+          });
+
+    const { result, rerender: resultRerender } = renderHook(() => {
+      const stateAndOnChanges = useTableSearchParams(mockRouter, options);
+      return useReactTable({
+        columns: [],
+        data: [],
+        getCoreRowModel: getCoreRowModel(),
+        ...stateAndOnChanges,
+      });
+    });
+
+    const defaultGlobalFilter =
+      options?.defaultValues?.globalFilter ?? defaultDefaultGlobalFilter;
+    const defaultSorting = options?.defaultValues?.sorting ?? [];
+    const defaultColumnFilters = options?.defaultValues?.columnFilters ?? [];
+    const defaultColumnOrder = options?.defaultValues?.columnOrder ?? [];
+    const defaultRowSelection = options?.defaultValues?.rowSelection ?? {};
+    const defaultPagination = options?.defaultValues?.pagination ?? {
+      pageIndex: 0,
+      pageSize: 10,
+    };
+
+    const defaultState: TableState = {
+      ...emptyState,
+      globalFilter: defaultGlobalFilter,
+      sorting: defaultSorting,
+      columnFilters: defaultColumnFilters,
+      columnOrder: defaultColumnOrder,
+      rowSelection: defaultRowSelection,
+      pagination: defaultPagination,
+    };
+
+    // initial state
+    expect(result.current.getState()).toStrictEqual(defaultState);
+    expect(mockRouter.query).toEqual({});
+
+    const newState: TableState = {
+      ...emptyState,
+      globalFilter: "John",
+      sorting: [{ id: "column1", desc: true }],
+      columnFilters: [{ id: "column1", value: "value" }],
+      columnOrder: ["column1"],
+      rowSelection: { row1: true },
+      pagination: { pageIndex: 1, pageSize: 20 },
+    };
+
+    const rerender = () => {
+      if (typeof options?.debounceMilliseconds === "number") {
+        vi.advanceTimersByTime(options.debounceMilliseconds);
+      }
+      resultRerender();
+    };
+
+    act(() => result.current.setState(newState));
+    rerender();
+    expect(result.current.getState()).toStrictEqual(newState);
+    expect(mockRouter.query).toEqual({
+      ...(options?.encoders?.globalFilter?.(newState.globalFilter) ?? {
+        [globalFilterParamName]: newState.globalFilter,
+      }),
+      ...(options?.encoders?.sorting?.(newState.sorting) ?? {
+        [sortingParamName]: "column1.desc",
+      }),
+      ...(options?.encoders?.columnFilters?.(newState.columnFilters) ?? {
+        [columnFiltersParamName]: "column1.%22value%22",
+      }),
+      ...(options?.encoders?.columnOrder?.(newState.columnOrder) ?? {
+        [columnOrderParamName]: "column1",
+      }),
+      ...(options?.encoders?.rowSelection?.(newState.rowSelection) ?? {
+        [rowSelectionParamName]: "row1",
+      }),
+      ...(options?.encoders?.pagination?.(newState.pagination) ?? {
+        [paginationParamName.pageIndex]: `${newState.pagination.pageIndex + 1}`,
+        [paginationParamName.pageSize]: `${newState.pagination.pageSize}`,
+      }),
+    });
+
+    act(() => result.current.reset());
+    rerender();
+
+    expect(result.current.getState()).toStrictEqual(emptyState);
+    expect(mockRouter.query).toEqual({
+      ...(options?.encoders?.globalFilter?.("") ?? {
+        [globalFilterParamName]: defaultGlobalFilter
+          ? encodedEmptyStringForGlobalFilterCustomDefaultValue
+          : undefined,
+      }),
+      ...(options?.encoders?.sorting?.([]) ?? {
+        [sortingParamName]:
+          defaultSorting.length > 0
+            ? noneStringForCustomDefaultValue
+            : undefined,
+      }),
+      ...(options?.encoders?.columnFilters?.([]) ?? {
+        [columnFiltersParamName]:
+          defaultColumnFilters.length > 0
+            ? noneStringForCustomDefaultValue
+            : undefined,
+      }),
+      ...(options?.encoders?.columnOrder?.([]) ?? {
+        [columnOrderParamName]:
+          defaultColumnOrder.length > 0
+            ? noneStringForCustomDefaultValue
+            : undefined,
+      }),
+      ...(options?.encoders?.rowSelection?.({}) ?? {
+        [rowSelectionParamName]:
+          Object.keys(defaultRowSelection).length > 0
+            ? noneStringForCustomDefaultValue
+            : undefined,
+      }),
+      ...(options?.encoders?.pagination?.(defaultPagination) ??
+        (options?.defaultValues?.pagination
+          ? {
+              [paginationParamName.pageIndex]: "1",
+              [paginationParamName.pageSize]: "10",
+            }
+          : {})),
+    });
+  });
+});

--- a/packages/tanstack-table-search-params/src/tests/onStateChange.test.ts
+++ b/packages/tanstack-table-search-params/src/tests/onStateChange.test.ts
@@ -1,0 +1,458 @@
+import {
+  getCoreRowModel,
+  type TableState,
+  useReactTable,
+} from "@tanstack/react-table";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { type State, useTableSearchParams } from "..";
+import {
+  defaultDefaultGlobalFilter,
+  encodedEmptyStringForGlobalFilterCustomDefaultValue,
+} from "../encoder-decoder/globalFilter";
+import { noneStringForCustomDefaultValue } from "../encoder-decoder/noneStringForCustomDefaultValue";
+import { defaultDefaultPagination } from "../encoder-decoder/pagination";
+import { useTestRouter } from "./testRouter";
+
+const emptyState: TableState = {
+  globalFilter: "",
+  sorting: [],
+  columnFilters: [],
+  columnOrder: [],
+  rowSelection: {},
+  pagination: { pageIndex: 0, pageSize: 10 },
+  columnPinning: { left: [], right: [] },
+  expanded: {},
+  columnSizing: {},
+  grouping: [],
+  columnSizingInfo: {
+    columnSizingStart: [],
+    deltaOffset: null,
+    deltaPercentage: null,
+    isResizingColumn: false,
+    startOffset: null,
+    startSize: null,
+  },
+  rowPinning: { bottom: [], top: [] },
+  columnVisibility: {},
+};
+
+describe("onStateChange", () => {
+  beforeEach(vi.useFakeTimers);
+  afterEach(() => window.history.replaceState({}, "", "/"));
+  test.each<{
+    name: string;
+    options?: Parameters<typeof useTableSearchParams>[1];
+  }>([
+    { name: "no options" },
+    {
+      name: "with options: string param name",
+      options: {
+        paramNames: {
+          globalFilter: "GLOBAL_FILTER",
+          sorting: "SORTING",
+          columnFilters: "COLUMN_FILTERS",
+          columnOrder: "COLUMN_ORDER",
+          rowSelection: "ROW_SELECTION",
+          pagination: {
+            pageIndex: "PAGE_INDEX",
+            pageSize: "PAGE_SIZE",
+          },
+        },
+      },
+    },
+    {
+      name: "with options: function param name",
+      options: {
+        paramNames: {
+          globalFilter: (key) => `userTable-${key}`,
+          sorting: (key) => `userTable-${key}`,
+          columnFilters: (key) => `userTable-${key}`,
+          columnOrder: (key) => `userTable-${key}`,
+          rowSelection: (key) => `userTable-${key}`,
+          pagination: ({ pageIndex, pageSize }) => ({
+            pageIndex: `userTable-${pageIndex}`,
+            pageSize: `userTable-${pageSize}`,
+          }),
+        },
+      },
+    },
+    {
+      name: "with options: default param name encoder/decoder",
+      options: {
+        encoders: {
+          globalFilter: (globalFilter = "") => ({
+            globalFilter: JSON.stringify(globalFilter),
+          }),
+          sorting: (sorting) => ({
+            sorting: JSON.stringify(sorting),
+          }),
+          columnFilters: (columnFilters) => ({
+            columnFilters: JSON.stringify(columnFilters),
+          }),
+          columnOrder: (columnOrder) => ({
+            columnOrder: JSON.stringify(columnOrder),
+          }),
+          rowSelection: (rowSelection) => ({
+            rowSelection: JSON.stringify(rowSelection),
+          }),
+          pagination: (pagination) => ({
+            pageIndex: JSON.stringify(pagination.pageIndex),
+            pageSize: JSON.stringify(pagination.pageSize),
+          }),
+        },
+        decoders: {
+          globalFilter: (query) =>
+            query["globalFilter"]
+              ? JSON.parse(query["globalFilter"] as string)
+              : (query["globalFilter"] ?? ""),
+          sorting: (query) =>
+            query["sorting"]
+              ? JSON.parse(query["sorting"] as string)
+              : query["sorting"],
+          columnFilters: (query) =>
+            query["columnFilters"]
+              ? JSON.parse(query["columnFilters"] as string)
+              : query["columnFilters"],
+          columnOrder: (query) =>
+            query["columnOrder"]
+              ? JSON.parse(query["columnOrder"] as string)
+              : query["columnOrder"],
+          rowSelection: (query) =>
+            query["rowSelection"]
+              ? JSON.parse(query["rowSelection"] as string)
+              : query["rowSelection"],
+          pagination: (query) => ({
+            pageIndex: query["pageIndex"]
+              ? JSON.parse(query["pageIndex"] as string)
+              : defaultDefaultPagination.pageIndex,
+            pageSize: query["pageSize"]
+              ? JSON.parse(query["pageSize"] as string)
+              : defaultDefaultPagination.pageSize,
+          }),
+        },
+      },
+    },
+    {
+      name: "with options: custom param name encoder/decoder",
+      options: {
+        encoders: {
+          globalFilter: (globalFilter = "") => ({
+            "userTable-globalFilter": JSON.stringify(globalFilter),
+          }),
+          sorting: (sorting) => ({
+            "userTable-sorting": JSON.stringify(sorting),
+          }),
+          columnFilters: (columnFilters) => ({
+            "userTable-columnFilters": JSON.stringify(columnFilters),
+          }),
+          columnOrder: (columnOrder) => ({
+            "userTable-columnOrder": JSON.stringify(columnOrder),
+          }),
+          rowSelection: (rowSelection) => ({
+            "userTable-rowSelection": JSON.stringify(rowSelection),
+          }),
+          pagination: (pagination) => ({
+            "userTable-pageIndex": JSON.stringify(pagination.pageIndex),
+            "userTable-pageSize": JSON.stringify(pagination.pageSize),
+          }),
+        },
+        decoders: {
+          globalFilter: (query) =>
+            query["userTable-globalFilter"]
+              ? JSON.parse(query["userTable-globalFilter"] as string)
+              : (query["userTable-globalFilter"] ?? ""),
+          sorting: (query) =>
+            query["userTable-sorting"]
+              ? JSON.parse(query["userTable-sorting"] as string)
+              : query["userTable-sorting"],
+          columnFilters: (query) =>
+            query["userTable-columnFilters"]
+              ? JSON.parse(query["userTable-columnFilters"] as string)
+              : query["userTable-columnFilters"],
+          columnOrder: (query) =>
+            query["userTable-columnOrder"]
+              ? JSON.parse(query["userTable-columnOrder"] as string)
+              : query["userTable-columnOrder"],
+          rowSelection: (query) =>
+            query["userTable-rowSelection"]
+              ? JSON.parse(query["userTable-rowSelection"] as string)
+              : query["userTable-rowSelection"],
+          pagination: (query) => ({
+            pageIndex: query["userTable-pageIndex"]
+              ? JSON.parse(query["userTable-pageIndex"] as string)
+              : defaultDefaultPagination.pageIndex,
+            pageSize: query["userTable-pageSize"]
+              ? JSON.parse(query["userTable-pageSize"] as string)
+              : defaultDefaultPagination.pageSize,
+          }),
+        },
+      },
+    },
+    {
+      name: "with options: custom number of params encoder/decoder",
+      options: {
+        encoders: {
+          sorting: (sorting) =>
+            Object.fromEntries(
+              sorting.map(({ id, desc }) => [
+                `sorting.${id}`,
+                desc ? "desc" : "asc",
+              ]),
+            ),
+          columnFilters: (columnFilters) =>
+            Object.fromEntries(
+              columnFilters.map(({ id, value }) => [
+                `columnFilters.${id}`,
+                JSON.stringify(value),
+              ]),
+            ),
+          columnOrder: (columnOrder) =>
+            Object.fromEntries(
+              columnOrder.map((value, i) => [
+                `columnOrder.${i}`,
+                JSON.stringify(value),
+              ]),
+            ),
+          rowSelection: (rowSelection) =>
+            Object.fromEntries(
+              Object.keys(rowSelection).map((id) => [
+                `rowSelection.${id}`,
+                "true",
+              ]),
+            ),
+          pagination: (pagination) => ({
+            pagination: JSON.stringify(pagination),
+          }),
+        },
+        decoders: {
+          sorting: (query) =>
+            Object.entries(query)
+              .filter(([key]) => key.startsWith("sorting."))
+              .map(([key, desc]) => ({
+                id: key.replace("sorting.", ""),
+                desc: desc === "desc",
+              })),
+          columnFilters: (query) =>
+            Object.entries(query)
+              .filter(([key]) => key.startsWith("columnFilters."))
+              .map(([key, value]) => ({
+                id: key.replace("columnFilters.", ""),
+                value: JSON.parse(value as string),
+              })),
+          columnOrder: (query) =>
+            Object.entries(query)
+              .filter(([key]) => key.startsWith("columnOrder."))
+              .map(([_, value]) => JSON.parse(value as string)),
+          rowSelection: (query) =>
+            Object.fromEntries(
+              Object.entries(query)
+                .filter(([key]) => key.startsWith("rowSelection."))
+                .map(([key]) => [key.replace("rowSelection.", ""), true]),
+            ),
+          pagination: (query) =>
+            query["pagination"]
+              ? JSON.parse(query["pagination"] as string)
+              : defaultDefaultPagination,
+        },
+      },
+    },
+    {
+      name: "with options: custom default value",
+      options: {
+        defaultValues: {
+          globalFilter: "default",
+          sorting: [{ id: "name", desc: true }],
+          columnFilters: [{ id: "custom", value: "default" }],
+          columnOrder: ["name", "id"],
+          rowSelection: { "1": true },
+          pagination: { pageIndex: 3, pageSize: 25 },
+        },
+      },
+    },
+    {
+      name: "with options: debounce milliseconds",
+      options: { debounceMilliseconds: 1 },
+    },
+    {
+      name: "with options: custom param name, default value",
+      options: {
+        paramNames: {
+          globalFilter: "GLOBAL_FILTER",
+          sorting: "SORTING",
+          columnFilters: "COLUMN_FILTERS",
+          columnOrder: "COLUMN_ORDER",
+          rowSelection: "ROW_SELECTION",
+          pagination: { pageIndex: "PAGE_INDEX", pageSize: "PAGE_SIZE" },
+        },
+        defaultValues: {
+          globalFilter: "default",
+          sorting: [{ id: "name", desc: true }],
+          columnFilters: [{ id: "custom", value: "default" }],
+          columnOrder: ["name", "id"],
+          rowSelection: { "1": true },
+          pagination: { pageIndex: 3, pageSize: 25 },
+        },
+      },
+    },
+  ])("%s", ({ options }) => {
+    const getParamName = (
+      name: Extract<
+        keyof State,
+        | "globalFilter"
+        | "sorting"
+        | "columnFilters"
+        | "columnOrder"
+        | "rowSelection"
+      >,
+    ) => {
+      const paramName = options?.paramNames?.[name];
+      return typeof paramName === "function"
+        ? paramName(name as never)
+        : paramName || name;
+    };
+
+    const globalFilterParamName = getParamName("globalFilter");
+    const sortingParamName = getParamName("sorting");
+    const columnFiltersParamName = getParamName("columnFilters");
+    const columnOrderParamName = getParamName("columnOrder");
+    const rowSelectionParamName = getParamName("rowSelection");
+    const paginationParamName =
+      typeof options?.paramNames?.pagination === "function"
+        ? options.paramNames.pagination({
+            pageIndex: "pageIndex",
+            pageSize: "pageSize",
+          })
+        : (options?.paramNames?.pagination ?? {
+            pageIndex: "pageIndex",
+            pageSize: "pageSize",
+          });
+
+    const { result: routerResult, rerender: routerRerender } = renderHook(() =>
+      useTestRouter(),
+    );
+    const { result, rerender: resultRerender } = renderHook(() => {
+      const stateAndOnChanges = useTableSearchParams(
+        routerResult.current,
+        options,
+      );
+      return useReactTable({
+        columns: [],
+        data: [],
+        getCoreRowModel: getCoreRowModel(),
+        ...stateAndOnChanges,
+      });
+    });
+
+    const defaultGlobalFilter =
+      options?.defaultValues?.globalFilter ?? defaultDefaultGlobalFilter;
+    const defaultSorting = options?.defaultValues?.sorting ?? [];
+    const defaultColumnFilters = options?.defaultValues?.columnFilters ?? [];
+    const defaultColumnOrder = options?.defaultValues?.columnOrder ?? [];
+    const defaultRowSelection = options?.defaultValues?.rowSelection ?? {};
+    const defaultPagination = options?.defaultValues?.pagination ?? {
+      pageIndex: 0,
+      pageSize: 10,
+    };
+
+    const defaultState: TableState = {
+      ...emptyState,
+      globalFilter: defaultGlobalFilter,
+      sorting: defaultSorting,
+      columnFilters: defaultColumnFilters,
+      columnOrder: defaultColumnOrder,
+      rowSelection: defaultRowSelection,
+      pagination: defaultPagination,
+    };
+
+    // initial state
+    expect(result.current.getState()).toStrictEqual(defaultState);
+    expect(routerResult.current.query).toEqual({});
+
+    const newState: TableState = {
+      ...emptyState,
+      globalFilter: "John",
+      sorting: [{ id: "column1", desc: true }],
+      columnFilters: [{ id: "column1", value: "value" }],
+      columnOrder: ["column1"],
+      rowSelection: { row1: true },
+      pagination: { pageIndex: 1, pageSize: 20 },
+    };
+
+    const rerender = () => {
+      if (typeof options?.debounceMilliseconds === "number") {
+        vi.advanceTimersByTime(options.debounceMilliseconds);
+      }
+      routerRerender();
+      resultRerender();
+    };
+
+    act(() => result.current.setState(newState));
+    rerender();
+    expect(result.current.getState()).toStrictEqual(newState);
+    expect(routerResult.current.query).toEqual({
+      ...(options?.encoders?.globalFilter?.(newState.globalFilter) ?? {
+        [globalFilterParamName]: newState.globalFilter,
+      }),
+      ...(options?.encoders?.sorting?.(newState.sorting) ?? {
+        [sortingParamName]: "column1.desc",
+      }),
+      ...(options?.encoders?.columnFilters?.(newState.columnFilters) ?? {
+        [columnFiltersParamName]: "column1.%22value%22",
+      }),
+      ...(options?.encoders?.columnOrder?.(newState.columnOrder) ?? {
+        [columnOrderParamName]: "column1",
+      }),
+      ...(options?.encoders?.rowSelection?.(newState.rowSelection) ?? {
+        [rowSelectionParamName]: "row1",
+      }),
+      ...(options?.encoders?.pagination?.(newState.pagination) ?? {
+        [paginationParamName.pageIndex]: `${newState.pagination.pageIndex + 1}`,
+        [paginationParamName.pageSize]: `${newState.pagination.pageSize}`,
+      }),
+    });
+
+    act(() => result.current.reset());
+    rerender();
+
+    expect(result.current.getState()).toStrictEqual(emptyState);
+    expect(routerResult.current.query).toEqual({
+      ...(options?.encoders?.globalFilter?.("") ?? {
+        [globalFilterParamName]: defaultGlobalFilter
+          ? encodedEmptyStringForGlobalFilterCustomDefaultValue
+          : undefined,
+      }),
+      ...(options?.encoders?.sorting?.([]) ?? {
+        [sortingParamName]:
+          defaultSorting.length > 0
+            ? noneStringForCustomDefaultValue
+            : undefined,
+      }),
+      ...(options?.encoders?.columnFilters?.([]) ?? {
+        [columnFiltersParamName]:
+          defaultColumnFilters.length > 0
+            ? noneStringForCustomDefaultValue
+            : undefined,
+      }),
+      ...(options?.encoders?.columnOrder?.([]) ?? {
+        [columnOrderParamName]:
+          defaultColumnOrder.length > 0
+            ? noneStringForCustomDefaultValue
+            : undefined,
+      }),
+      ...(options?.encoders?.rowSelection?.({}) ?? {
+        [rowSelectionParamName]:
+          Object.keys(defaultRowSelection).length > 0
+            ? noneStringForCustomDefaultValue
+            : undefined,
+      }),
+      ...(options?.encoders?.pagination?.(defaultPagination) ??
+        (options?.defaultValues?.pagination
+          ? {
+              [paginationParamName.pageIndex]: "1",
+              [paginationParamName.pageSize]: "10",
+            }
+          : {})),
+    });
+  });
+});


### PR DESCRIPTION
## What

Supports [`onStateChange`](https://tanstack.com/table/latest/docs/api/core/table#onstatechange).

This change ensures that the table state is synchronized with URL parameters even when [`table.setState()`](https://tanstack.com/table/latest/docs/api/core/table#setstate) or [`table.reset()`](https://tanstack.com/table/latest/docs/api/core/table#reset) is executed.

## Usage

Since `onStateChange` has been added to the return value of `useTableSearchParams`, you can simply set it in `useReactTable`.

```tsx
const router = useRouter();

// `onStateChange` is added into `stateAndOnChanges`!
const stateAndOnChanges = useTableSearchParams(router);

const table = useReactTable({
  ...stateAndOnChanges,
  data,
  columns,
  getCoreRowModel: getCoreRowModel(),
  // ...
});

const handleXXX = () => {
  table.reset();
  // or
  table.setState({
    globalFilter: "",
    sorting: [],
  });
};
```


## Related Issue

- https://github.com/taro-28/tanstack-table-search-params/issues/534