### PR TITLE
Support `columnVisibility`

### DIFF
--- a/examples/lib/src/components/UserTable.tsx
+++ b/examples/lib/src/components/UserTable.tsx
@@ -48,6 +48,21 @@ export const UserTable = ({ table }: Props) => {
             {isReversed ? "Reset Order" : "Reverse Order"}
           </Button>
           <Button onClick={table.reset}>Reset State</Button>
+          <fieldset className="flex flex-col gap-2">
+            <legend className="font-bold">Column Visibility</legend>
+            <div className="flex flex-col gap-1">
+              {table.getAllLeafColumns().map((column) => (
+                <label key={column.id} className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={column.getIsVisible()}
+                    onChange={column.getToggleVisibilityHandler()}
+                  />
+                  {column.id}
+                </label>
+              ))}
+            </div>
+          </fieldset>
         </div>
         <div className="table border-2 border-gray-200 rounded-md ">
           <div className="table-header-group bg-slate-200">
@@ -240,6 +255,7 @@ export const UserTable = ({ table }: Props) => {
               columnFilters: table.getState().columnFilters,
               columnOrder: table.getState().columnOrder,
               rowSelection: table.getState().rowSelection,
+              columnVisibility: table.getState().columnVisibility,
             },
             null,
             2,

--- a/examples/next-app-router/src/app/custom-default-value/table.tsx
+++ b/examples/next-app-router/src/app/custom-default-value/table.tsx
@@ -33,6 +33,7 @@ export const Table = () => {
         columnFilters: [{ id: "name", value: "b" }],
         columnOrder: userColumns.reverse().map((c) => c.id as string),
         rowSelection: { "1": true },
+        columnVisibility: { id: false },
       },
     },
   );

--- a/examples/next-app-router/src/app/custom-encoder-decoder/table.tsx
+++ b/examples/next-app-router/src/app/custom-encoder-decoder/table.tsx
@@ -53,6 +53,9 @@ export const Table = () => {
         rowSelection: (rowSelection) => ({
           rowSelection: JSON.stringify(rowSelection),
         }),
+        columnVisibility: (columnVisibility) => ({
+          columnVisibility: JSON.stringify(columnVisibility),
+        }),
       },
       decoders: {
         globalFilter: (query) =>
@@ -87,6 +90,10 @@ export const Table = () => {
         rowSelection: (query) =>
           query["rowSelection"]
             ? JSON.parse(query["rowSelection"] as string)
+            : {},
+        columnVisibility: (query) =>
+          query["columnVisibility"]
+            ? JSON.parse(query["columnVisibility"] as string)
             : {},
       },
     },

--- a/examples/next-app-router/src/app/custom-param-name/table.tsx
+++ b/examples/next-app-router/src/app/custom-param-name/table.tsx
@@ -36,6 +36,7 @@ export const Table = () => {
         columnFilters: (defaultParamName) => `userTable-${defaultParamName}`,
         columnOrder: (defaultParamName) => `userTable-${defaultParamName}`,
         rowSelection: (defaultParamName) => `userTable-${defaultParamName}`,
+        columnVisibility: (defaultParamName) => `userTable-${defaultParamName}`,
       },
     },
   );

--- a/examples/next-app-router/src/app/debounce/table.tsx
+++ b/examples/next-app-router/src/app/debounce/table.tsx
@@ -33,6 +33,7 @@ export const Table = () => {
         columnFilters: 1000,
         columnOrder: 1000,
         rowSelection: 1000,
+        columnVisibility: 1000,
       },
     },
   );

--- a/examples/next-pages-router/src/pages/custom-default-value.tsx
+++ b/examples/next-pages-router/src/pages/custom-default-value.tsx
@@ -25,6 +25,7 @@ export default function CustomParamNames() {
       columnFilters: [{ id: "name", value: "b" }],
       columnOrder: userColumns.reverse().map((c) => c.id as string),
       rowSelection: { "1": true },
+      columnVisibility: { id: false },
     },
   });
 

--- a/examples/next-pages-router/src/pages/custom-encoder-decoder.tsx
+++ b/examples/next-pages-router/src/pages/custom-encoder-decoder.tsx
@@ -45,6 +45,9 @@ export default function CustomEncoderDecoder() {
       rowSelection: (rowSelection) => ({
         rowSelection: JSON.stringify(rowSelection),
       }),
+      columnVisibility: (columnVisibility) => ({
+        columnVisibility: JSON.stringify(columnVisibility),
+      }),
     },
     decoders: {
       globalFilter: (query) =>
@@ -77,6 +80,10 @@ export default function CustomEncoderDecoder() {
       rowSelection: (query) =>
         query["rowSelection"]
           ? JSON.parse(query["rowSelection"] as string)
+          : {},
+      columnVisibility: (query) =>
+        query["columnVisibility"]
+          ? JSON.parse(query["columnVisibility"] as string)
           : {},
     },
   });

--- a/examples/next-pages-router/src/pages/custom-param-name.tsx
+++ b/examples/next-pages-router/src/pages/custom-param-name.tsx
@@ -28,6 +28,7 @@ export default function CustomParamNames() {
       columnFilters: (defaultParamName) => `userTable-${defaultParamName}`,
       columnOrder: (defaultParamName) => `userTable-${defaultParamName}`,
       rowSelection: (defaultParamName) => `userTable-${defaultParamName}`,
+      columnVisibility: (defaultParamName) => `userTable-${defaultParamName}`,
     },
   });
 

--- a/examples/next-pages-router/src/pages/debounce.tsx
+++ b/examples/next-pages-router/src/pages/debounce.tsx
@@ -25,6 +25,7 @@ export default function Basic() {
       columnFilters: 1000,
       columnOrder: 1000,
       rowSelection: 1000,
+      columnVisibility: 1000,
     },
   });
 

--- a/examples/react-router-lib/src/custom-default-value.tsx
+++ b/examples/react-router-lib/src/custom-default-value.tsx
@@ -29,6 +29,7 @@ export default function CustomDefaultValuePage() {
         columnFilters: [{ id: "name", value: "b" }],
         columnOrder: userColumns.reverse().map((c) => c.id as string),
         rowSelection: { "1": true },
+        columnVisibility: { id: false },
       },
     },
   );

--- a/examples/react-router-lib/src/custom-encoder-decoder.tsx
+++ b/examples/react-router-lib/src/custom-encoder-decoder.tsx
@@ -49,6 +49,9 @@ export default function CustomEncoderDecoderPage() {
         rowSelection: (rowSelection) => ({
           rowSelection: JSON.stringify(rowSelection),
         }),
+        columnVisibility: (columnVisibility) => ({
+          columnVisibility: JSON.stringify(columnVisibility),
+        }),
       },
       decoders: {
         globalFilter: (query) =>
@@ -83,6 +86,10 @@ export default function CustomEncoderDecoderPage() {
         rowSelection: (query) =>
           query["rowSelection"]
             ? JSON.parse(query["rowSelection"] as string)
+            : {},
+        columnVisibility: (query) =>
+          query["columnVisibility"]
+            ? JSON.parse(query["columnVisibility"] as string)
             : {},
       },
     },

--- a/examples/react-router-lib/src/custom-param-name.tsx
+++ b/examples/react-router-lib/src/custom-param-name.tsx
@@ -32,6 +32,7 @@ export default function CustomParamNamePage() {
         columnFilters: (defaultParamName) => `userTable-${defaultParamName}`,
         columnOrder: (defaultParamName) => `userTable-${defaultParamName}`,
         rowSelection: (defaultParamName) => `userTable-${defaultParamName}`,
+        columnVisibility: (defaultParamName) => `userTable-${defaultParamName}`,
       },
     },
   );

--- a/examples/react-router-lib/src/debounce.tsx
+++ b/examples/react-router-lib/src/debounce.tsx
@@ -29,6 +29,7 @@ export default function DebouncePage() {
         columnFilters: 1000,
         columnOrder: 1000,
         rowSelection: 1000,
+        columnVisibility: 1000,
       },
     },
   );

--- a/examples/tanstack-router/src/routes/custom-default-value.tsx
+++ b/examples/tanstack-router/src/routes/custom-default-value.tsx
@@ -43,6 +43,7 @@ function Page() {
         columnFilters: [{ id: "name", value: "b" }],
         columnOrder: userColumns.reverse().map((c) => c.id as string),
         rowSelection: { "1": true },
+        columnVisibility: { id: false },
       },
     },
   );

--- a/examples/tanstack-router/src/routes/custom-encoder-decoder.tsx
+++ b/examples/tanstack-router/src/routes/custom-encoder-decoder.tsx
@@ -63,6 +63,9 @@ function Page() {
         rowSelection: (rowSelection) => ({
           rowSelection: JSON.stringify(rowSelection),
         }),
+        columnVisibility: (columnVisibility) => ({
+          columnVisibility: JSON.stringify(columnVisibility),
+        }),
       },
       decoders: {
         globalFilter: (query) =>
@@ -97,6 +100,10 @@ function Page() {
         rowSelection: (query) =>
           query["rowSelection"]
             ? JSON.parse(query["rowSelection"] as string)
+            : {},
+        columnVisibility: (query) =>
+          query["columnVisibility"]
+            ? JSON.parse(query["columnVisibility"] as string)
             : {},
       },
     },

--- a/examples/tanstack-router/src/routes/custom-param-name.tsx
+++ b/examples/tanstack-router/src/routes/custom-param-name.tsx
@@ -46,6 +46,7 @@ function Page() {
         columnFilters: (defaultParamName) => `userTable-${defaultParamName}`,
         columnOrder: (defaultParamName) => `userTable-${defaultParamName}`,
         rowSelection: (defaultParamName) => `userTable-${defaultParamName}`,
+        columnVisibility: (defaultParamName) => `userTable-${defaultParamName}`,
       },
     },
   );

--- a/examples/tanstack-router/src/routes/debounce.tsx
+++ b/examples/tanstack-router/src/routes/debounce.tsx
@@ -43,6 +43,7 @@ function Page() {
         columnFilters: 1000,
         columnOrder: 1000,
         rowSelection: 1000,
+        columnVisibility: 1000,
       },
     },
   );

--- a/packages/tanstack-table-search-params/README.md
+++ b/packages/tanstack-table-search-params/README.md
@@ -416,7 +416,7 @@ List of supported TanStack table states
 - [ ] columnPinning
 - [ ] columnSizing
 - [ ] columnSizingInfo
-- [ ] columnVisibility
+- [x] columnVisibility
 - [ ] expanded
 - [ ] grouping
 - [ ] rowPinning

--- a/packages/tanstack-table-search-params/src/encoder-decoder/columnVisibility.test.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/columnVisibility.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "vitest";
+import {
+  decodeColumnVisibility,
+  defaultDefaultColumnVisibility,
+  encodeColumnVisibility,
+} from "./columnVisibility";
+import { noneStringForCustomDefaultValue } from "./noneStringForCustomDefaultValue";
+
+type DefaultValue = NonNullable<
+  NonNullable<Parameters<typeof encodeColumnVisibility>[1]>["defaultValue"]
+>;
+
+const customDefaultValue = { bar: false };
+
+describe("columnVisibility", () => {
+  describe("encode", () =>
+    describe.each<{ name: string; defaultValue: DefaultValue }>([
+      {
+        name: "default default value",
+        defaultValue: defaultDefaultColumnVisibility,
+      },
+      { name: "with custom default value", defaultValue: customDefaultValue },
+    ])("default value: $name", ({ defaultValue }) =>
+      test.each<{
+        name: string;
+        stateValue: Parameters<typeof encodeColumnVisibility>[0];
+        want: ReturnType<typeof encodeColumnVisibility>;
+      }>([
+        { name: "default value", stateValue: defaultValue, want: undefined },
+        {
+          name: "empty object",
+          stateValue: {},
+          want:
+            JSON.stringify(defaultValue) ===
+            JSON.stringify(defaultDefaultColumnVisibility)
+              ? undefined
+              : noneStringForCustomDefaultValue,
+        },
+        {
+          name: "true items",
+          stateValue: { foo: true, bar: true },
+          want:
+            JSON.stringify(defaultValue) ===
+            JSON.stringify(defaultDefaultColumnVisibility)
+              ? undefined
+              : noneStringForCustomDefaultValue,
+        },
+        {
+          name: "false items",
+          stateValue: { foo: false, bar: false },
+          want: "foo,bar",
+        },
+        {
+          name: "mixed items",
+          stateValue: { foo: false, bar: true },
+          want: "foo",
+        },
+      ])("$name", ({ stateValue, want }) =>
+        expect(encodeColumnVisibility(stateValue, { defaultValue })).toEqual(
+          want,
+        ),
+      ),
+    ));
+
+  describe("decode", () =>
+    describe.each<{ name: string; defaultValue: DefaultValue }>([
+      {
+        name: "default default value",
+        defaultValue: defaultDefaultColumnVisibility,
+      },
+      // { name: "with custom default value", defaultValue: customDefaultValue },
+    ])("default value: $name", ({ defaultValue }) =>
+      test.each<{
+        name: string;
+        queryValue: Parameters<typeof decodeColumnVisibility>[0];
+        want: ReturnType<typeof decodeColumnVisibility>;
+      }>([
+        {
+          name: "default value",
+          queryValue: encodeColumnVisibility(defaultValue, { defaultValue }),
+          want: defaultValue,
+        },
+        { name: "empty string", queryValue: "", want: defaultValue },
+        {
+          name: "noneStringForCustomDefaultValue",
+          queryValue: noneStringForCustomDefaultValue,
+          want: {},
+        },
+        { name: "string", queryValue: "foo", want: { foo: false } },
+        {
+          name: "string array",
+          queryValue: "foo,bar",
+          want: { foo: false, bar: false },
+        },
+        { name: "undefined", queryValue: undefined, want: defaultValue },
+      ])("$name", ({ queryValue, want }) =>
+        expect(decodeColumnVisibility(queryValue, { defaultValue })).toEqual(
+          want,
+        ),
+      ),
+    ));
+
+  describe("encode and decode", () =>
+    describe.each<{ name: string; defaultValue: DefaultValue }>([
+      {
+        name: "default default value",
+        defaultValue: defaultDefaultColumnVisibility,
+      },
+      { name: "with custom default value", defaultValue: customDefaultValue },
+    ])("default value: $name", ({ defaultValue }) =>
+      test.each<{
+        name: string;
+        stateValue: Parameters<typeof encodeColumnVisibility>[0];
+      }>([
+        { name: "default value", stateValue: defaultValue },
+        { name: "empty object", stateValue: {} },
+        { name: "false items", stateValue: { foo: false, bar: false } },
+      ])("$name", ({ stateValue }) => {
+        expect(
+          decodeColumnVisibility(
+            encodeColumnVisibility(stateValue, { defaultValue }),
+            { defaultValue },
+          ),
+        ).toEqual(stateValue);
+      }),
+    ));
+});

--- a/packages/tanstack-table-search-params/src/encoder-decoder/columnVisibility.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/columnVisibility.ts
@@ -1,0 +1,69 @@
+import type { State as TanstackTableState } from "..";
+import type { Query } from "../types";
+import { noneStringForCustomDefaultValue } from "./noneStringForCustomDefaultValue";
+
+export const defaultDefaultColumnVisibility =
+  {} as const satisfies TanstackTableState["columnVisibility"];
+
+const extractFalseProperties = (
+  value: TanstackTableState["columnVisibility"],
+) => Object.fromEntries(Object.entries(value).filter(([, v]) => !v));
+
+/**
+ * The default encoder of Tanstack Table's `columnVisibility`.
+ *
+ * @param value - The value to encode.
+ * @param options
+ * @param options.defaultValue
+ * - If you set [`defaultValues`](https://github.com/taro-28/tanstack-table-search-params?tab=readme-ov-file#custom-default-value) in `useTableSearchParams`,
+ * you should set the same value.
+ *
+ * @returns The encoded query parameter value.
+ */
+export const encodeColumnVisibility = (
+  value: TanstackTableState["columnVisibility"],
+  options?: { defaultValue?: TanstackTableState["columnVisibility"] },
+): Query[string] => {
+  const defaultValue = options?.defaultValue ?? defaultDefaultColumnVisibility;
+  const extractedValue = extractFalseProperties(value);
+  if (
+    JSON.stringify(extractedValue) ===
+    JSON.stringify(extractFalseProperties(defaultValue))
+  ) {
+    return undefined;
+  }
+
+  // return encoded empty string if stateValue is empty with custom default value
+  if (Object.keys(extractedValue).length === 0) {
+    return noneStringForCustomDefaultValue;
+  }
+
+  return Object.entries(extractedValue)
+    .map(([id]) => id)
+    .join(",");
+};
+
+/**
+ * The default decoder of Tanstack Table's `columnVisibility`.
+ *
+ * @param value - The encoded query parameter value to decode.
+ * @param options
+ * @param options.defaultValue
+ * - If you set [`defaultValues`](https://github.com/taro-28/tanstack-table-search-params?tab=readme-ov-file#custom-default-value) in `useTableSearchParams`,
+ * you should set the same value.
+ *
+ * @returns The decoded value.
+ */
+export const decodeColumnVisibility = (
+  value: Query[string],
+  options?: { defaultValue?: TanstackTableState["columnVisibility"] },
+): TanstackTableState["columnVisibility"] => {
+  const defaultValue = options?.defaultValue ?? defaultDefaultColumnVisibility;
+  if (typeof value !== "string") return defaultValue;
+  if (value === "") return defaultValue;
+  if (value === noneStringForCustomDefaultValue) {
+    return {};
+  }
+
+  return Object.fromEntries(value.split(",").map((id) => [id, false]));
+};

--- a/packages/tanstack-table-search-params/src/encoder-decoder/index.ts
+++ b/packages/tanstack-table-search-params/src/encoder-decoder/index.ts
@@ -1,5 +1,9 @@
 export { decodeColumnFilters, encodeColumnFilters } from "./columnFilters";
 export { decodeColumnOrder, encodeColumnOrder } from "./columnOrder";
+export {
+  decodeColumnVisibility,
+  encodeColumnVisibility,
+} from "./columnVisibility";
 export { decodeGlobalFilter, encodeGlobalFilter } from "./globalFilter";
 export { decodePagination, encodePagination } from "./pagination";
 export { decodeRowSelection, encodeRowSelection } from "./rowSelection";

--- a/packages/tanstack-table-search-params/src/index.ts
+++ b/packages/tanstack-table-search-params/src/index.ts
@@ -9,6 +9,7 @@ import type { Query, Router } from "./types";
 import { updateQuery } from "./updateQuery";
 import { useColumnFilters } from "./useColumnFilters";
 import { useColumnOrder } from "./useColumnOrder";
+import { useColumnVisibility } from "./useColumnVisibility";
 import { useGlobalFilter } from "./useGlobalFilter";
 import { usePagination } from "./usePagination";
 import { useRowSelection } from "./useRowSelection";
@@ -23,6 +24,7 @@ export type State = Pick<
   | "columnFilters"
   | "columnOrder"
   | "rowSelection"
+  | "columnVisibility"
 >;
 
 export const PARAM_NAMES = {
@@ -33,6 +35,7 @@ export const PARAM_NAMES = {
   COLUMN_FILTERS: "columnFilters",
   COLUMN_ORDER: "columnOrder",
   ROW_SELECTION: "rowSelection",
+  COLUMN_VISIBILITY: "columnVisibility",
 } as const;
 
 export type Returns = {
@@ -64,6 +67,10 @@ export type Returns = {
    * Tanstack Table's `onChangeRowSelection` function
    */
   onRowSelectionChange: OnChangeFn<State["rowSelection"]>;
+  /**
+   * Tanstack Table's `onChangeColumnVisibility` function
+   */
+  onColumnVisibilityChange: OnChangeFn<State["columnVisibility"]>;
   onStateChange: (updater: Updater<TableState>) => void;
 };
 
@@ -220,6 +227,14 @@ export const useTableSearchParams = (
       router,
       options: extractSpecificStateOptions({ options, key: "rowSelection" }),
     });
+  const {
+    columnVisibility,
+    columnVisibilityEncoder,
+    onColumnVisibilityChange,
+  } = useColumnVisibility({
+    router,
+    options: extractSpecificStateOptions({ options, key: "columnVisibility" }),
+  });
 
   const state = useMemo(
     () => ({
@@ -229,6 +244,7 @@ export const useTableSearchParams = (
       columnFilters,
       columnOrder,
       rowSelection,
+      columnVisibility,
     }),
     [
       sorting,
@@ -237,6 +253,7 @@ export const useTableSearchParams = (
       columnFilters,
       columnOrder,
       rowSelection,
+      columnVisibility,
     ],
   );
 
@@ -266,6 +283,7 @@ export const useTableSearchParams = (
         ...columnFiltersEncoder(state.columnFilters),
         ...columnOrderEncoder(state.columnOrder),
         ...rowSelectionEncoder(state.rowSelection),
+        ...columnVisibilityEncoder(state.columnVisibility),
       });
       await updateQuery({
         oldQuery: encodeState(state),
@@ -282,6 +300,7 @@ export const useTableSearchParams = (
       columnFiltersEncoder,
       columnOrderEncoder,
       rowSelectionEncoder,
+      columnVisibilityEncoder,
     ],
   );
 
@@ -293,6 +312,7 @@ export const useTableSearchParams = (
     onColumnFiltersChange,
     onColumnOrderChange,
     onRowSelectionChange,
+    onColumnVisibilityChange,
     onStateChange,
   };
 };

--- a/packages/tanstack-table-search-params/src/tests/columnVisibility.test.ts
+++ b/packages/tanstack-table-search-params/src/tests/columnVisibility.test.ts
@@ -1,0 +1,242 @@
+import { getCoreRowModel, useReactTable } from "@tanstack/react-table";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { type State, useTableSearchParams } from "..";
+import {
+  defaultDefaultColumnVisibility,
+  encodeColumnVisibility as defaultEncoder,
+} from "../encoder-decoder/columnVisibility";
+import { noneStringForCustomDefaultValue } from "../encoder-decoder/noneStringForCustomDefaultValue";
+import { useTestRouter } from "./testRouter";
+import { typedObjectEntries } from "./utils";
+
+type ColumnVisibility = State["columnVisibility"];
+
+const toggleColumnVisibilityState = (
+  state: ColumnVisibility,
+  id: string,
+): ColumnVisibility =>
+  Object.fromEntries(
+    typedObjectEntries({
+      ...state,
+      [id]: state[id] === undefined ? false : !state[id],
+    }),
+  );
+
+const extractFalseProperties = (state: ColumnVisibility) =>
+  Object.fromEntries(
+    typedObjectEntries({ ...state }).filter(([_, value]) => !value),
+  );
+
+describe("columnVisibility", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => window.history.replaceState({}, "", "/"));
+  describe.each<{
+    name: string;
+    options?: Parameters<typeof useTableSearchParams>[1];
+  }>([
+    { name: "no options" },
+    {
+      name: "with options: string param name",
+      options: { paramNames: { columnVisibility: "COLUMN_VISIBILITY" } },
+    },
+    {
+      name: "with options: function param name",
+      options: {
+        paramNames: { columnVisibility: (key) => `userTable-${key}` },
+      },
+    },
+    {
+      name: "with options: default param name encoder/decoder",
+      options: {
+        encoders: {
+          columnVisibility: (columnVisibility) => ({
+            columnVisibility: JSON.stringify(columnVisibility),
+          }),
+        },
+        decoders: {
+          columnVisibility: (query) =>
+            query["columnVisibility"]
+              ? JSON.parse(query["columnVisibility"] as string)
+              : query["columnVisibility"],
+        },
+      },
+    },
+    {
+      name: "with options: custom param name encoder/decoder",
+      options: {
+        encoders: {
+          columnVisibility: (columnVisibility) => ({
+            "userTable-columnVisibility": JSON.stringify(columnVisibility),
+          }),
+        },
+        decoders: {
+          columnVisibility: (query) =>
+            query["userTable-columnVisibility"]
+              ? JSON.parse(query["userTable-columnVisibility"] as string)
+              : query["userTable-columnVisibility"],
+        },
+      },
+    },
+    {
+      name: "with options: custom number of params encoder/decoder",
+      options: {
+        encoders: {
+          columnVisibility: (columnVisibility) =>
+            Object.fromEntries(
+              Object.entries(columnVisibility).map(([id, value]) => [
+                `columnVisibility.${id}`,
+                value ? "true" : "false",
+              ]),
+            ),
+        },
+        decoders: {
+          columnVisibility: (query) =>
+            Object.fromEntries(
+              Object.entries(query)
+                .filter(([key]) => key.startsWith("columnVisibility."))
+                .map(([key, value]) => [
+                  key.replace("columnVisibility.", ""),
+                  value === "true",
+                ]),
+            ),
+        },
+      },
+    },
+    {
+      name: "with options: custom default value",
+      options: { defaultValues: { columnVisibility: { id: true } } },
+    },
+    {
+      name: "with options: debounce milliseconds",
+      options: { debounceMilliseconds: 1 },
+    },
+    {
+      name: "with options: debounce milliseconds for columnVisibility",
+      options: { debounceMilliseconds: { columnVisibility: 1 } },
+    },
+    {
+      name: "with options: custom param name, default value, debounce",
+      options: {
+        paramNames: { columnVisibility: "COLUMN_VISIBILITY" },
+        defaultValues: { columnVisibility: { id: true } },
+        debounceMilliseconds: 1,
+      },
+    },
+  ])("%s", ({ options }) => {
+    const paramName =
+      typeof options?.paramNames?.columnVisibility === "function"
+        ? options.paramNames.columnVisibility("columnVisibility")
+        : options?.paramNames?.columnVisibility || "columnVisibility";
+
+    const defaultValue: State["columnVisibility"] =
+      options?.defaultValues?.columnVisibility ??
+      defaultDefaultColumnVisibility;
+
+    const debounceMilliseconds =
+      options?.debounceMilliseconds !== undefined
+        ? typeof options.debounceMilliseconds === "object"
+          ? options.debounceMilliseconds.columnVisibility
+          : options.debounceMilliseconds
+        : undefined;
+
+    test("basic", () => {
+      const { result: routerResult, rerender: routerRerender } = renderHook(
+        () => useTestRouter(),
+      );
+      const { result, rerender: resultRerender } = renderHook(() => {
+        const stateAndOnChanges = useTableSearchParams(
+          routerResult.current,
+          options,
+        );
+        return useReactTable({
+          columns: [{ id: "id" }, { id: "name" }],
+          data: [],
+          getCoreRowModel: getCoreRowModel(),
+          ...stateAndOnChanges,
+        });
+      });
+      const rerender = () => {
+        if (debounceMilliseconds) {
+          vi.advanceTimersByTime(debounceMilliseconds);
+        }
+        routerRerender();
+        resultRerender();
+      };
+
+      const encoder = options?.encoders?.columnVisibility;
+
+      // initial state
+      const wantInitialState = defaultValue;
+      expect(
+        extractFalseProperties(result.current.getState().columnVisibility),
+      ).toEqual(extractFalseProperties(wantInitialState));
+      expect(routerResult.current.query).toEqual({});
+
+      // toggle first column (id)
+      act(() => result.current.getColumn("id")?.toggleVisibility());
+      rerender();
+      const wantToggledFirstColumnState = toggleColumnVisibilityState(
+        wantInitialState,
+        "id",
+      );
+      expect(
+        extractFalseProperties(result.current.getState().columnVisibility),
+      ).toEqual(extractFalseProperties(wantToggledFirstColumnState));
+      expect(routerResult.current.query).toEqual(
+        encoder?.(wantToggledFirstColumnState) ?? {
+          [paramName]: defaultEncoder(wantToggledFirstColumnState),
+        },
+      );
+
+      // toggle second column (name)
+      act(() => result.current.getColumn("name")?.toggleVisibility());
+      rerender();
+      const wantRetoggledFirstColumnState = toggleColumnVisibilityState(
+        wantToggledFirstColumnState,
+        "name",
+      );
+      expect(
+        extractFalseProperties(result.current.getState().columnVisibility),
+      ).toEqual(extractFalseProperties(wantRetoggledFirstColumnState));
+      expect(routerResult.current.query).toEqual(
+        encoder?.(wantRetoggledFirstColumnState) ?? {
+          [paramName]: defaultEncoder(wantRetoggledFirstColumnState),
+        },
+      );
+
+      // toggle first column (id)
+      act(() => result.current.getColumn("id")?.toggleVisibility());
+      rerender();
+      const wantToggledSecondColumnState = toggleColumnVisibilityState(
+        wantRetoggledFirstColumnState,
+        "id",
+      );
+      expect(
+        extractFalseProperties(result.current.getState().columnVisibility),
+      ).toEqual(extractFalseProperties(wantToggledSecondColumnState));
+      expect(routerResult.current.query).toEqual(
+        encoder?.(wantToggledSecondColumnState) ?? {
+          [paramName]:
+            Object.keys(wantToggledSecondColumnState).length === 0
+              ? noneStringForCustomDefaultValue
+              : defaultEncoder(wantToggledSecondColumnState),
+        },
+      );
+
+      // toggle second column (name)
+      act(() => result.current.getColumn("name")?.toggleVisibility());
+      rerender();
+      const wantRetoggledSecondColumnState = toggleColumnVisibilityState(
+        wantToggledSecondColumnState,
+        "name",
+      );
+      expect(
+        extractFalseProperties(result.current.getState().columnVisibility),
+      ).toEqual(extractFalseProperties(wantRetoggledSecondColumnState));
+      expect(routerResult.current.query).toEqual(
+        encoder?.(wantRetoggledSecondColumnState) ?? {},
+      );
+    });
+  });
+});

--- a/packages/tanstack-table-search-params/src/tests/next-pages-router/columnVisibility.test.ts
+++ b/packages/tanstack-table-search-params/src/tests/next-pages-router/columnVisibility.test.ts
@@ -1,0 +1,237 @@
+import { getCoreRowModel, useReactTable } from "@tanstack/react-table";
+import { act, renderHook } from "@testing-library/react";
+import mockRouter from "next-router-mock";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { type State, useTableSearchParams } from "../..";
+import {
+  defaultDefaultColumnVisibility,
+  encodeColumnVisibility as defaultEncoder,
+} from "../../encoder-decoder/columnVisibility";
+import { noneStringForCustomDefaultValue } from "../../encoder-decoder/noneStringForCustomDefaultValue";
+import { typedObjectEntries } from "../utils";
+
+type ColumnVisibility = State["columnVisibility"];
+
+const toggleColumnVisibilityState = (
+  state: ColumnVisibility,
+  id: string,
+): ColumnVisibility =>
+  Object.fromEntries(
+    typedObjectEntries({
+      ...state,
+      [id]: state[id] === undefined ? false : !state[id],
+    }),
+  );
+
+const extractFalseProperties = (state: ColumnVisibility) =>
+  Object.fromEntries(
+    typedObjectEntries({ ...state }).filter(([_, value]) => !value),
+  );
+
+describe("columnVisibility", () => {
+  beforeEach(vi.useFakeTimers);
+  afterEach(() => {
+    mockRouter.query = {};
+  });
+  describe.each<{
+    name: string;
+    options?: Parameters<typeof useTableSearchParams>[1];
+  }>([
+    { name: "no options" },
+    {
+      name: "with options: string param name",
+      options: { paramNames: { columnVisibility: "COLUMN_VISIBILITY" } },
+    },
+    {
+      name: "with options: function param name",
+      options: {
+        paramNames: { columnVisibility: (key) => `userTable-${key}` },
+      },
+    },
+    {
+      name: "with options: default param name encoder/decoder",
+      options: {
+        encoders: {
+          columnVisibility: (columnVisibility) => ({
+            columnVisibility: JSON.stringify(columnVisibility),
+          }),
+        },
+        decoders: {
+          columnVisibility: (query) =>
+            query["columnVisibility"]
+              ? JSON.parse(query["columnVisibility"] as string)
+              : query["columnVisibility"],
+        },
+      },
+    },
+    {
+      name: "with options: custom param name encoder/decoder",
+      options: {
+        encoders: {
+          columnVisibility: (columnVisibility) => ({
+            "userTable-columnVisibility": JSON.stringify(columnVisibility),
+          }),
+        },
+        decoders: {
+          columnVisibility: (query) =>
+            query["userTable-columnVisibility"]
+              ? JSON.parse(query["userTable-columnVisibility"] as string)
+              : query["userTable-columnVisibility"],
+        },
+      },
+    },
+    {
+      name: "with options: custom number of params encoder/decoder",
+      options: {
+        encoders: {
+          columnVisibility: (columnVisibility) =>
+            Object.fromEntries(
+              Object.entries(columnVisibility).map(([id, value]) => [
+                `columnVisibility.${id}`,
+                value ? "true" : "false",
+              ]),
+            ),
+        },
+        decoders: {
+          columnVisibility: (query) =>
+            Object.fromEntries(
+              Object.entries(query)
+                .filter(([key]) => key.startsWith("columnVisibility."))
+                .map(([key, value]) => [
+                  key.replace("columnVisibility.", ""),
+                  value === "true",
+                ]),
+            ),
+        },
+      },
+    },
+    {
+      name: "with options: custom default value",
+      options: { defaultValues: { columnVisibility: { id: true } } },
+    },
+    {
+      name: "with options: debounce milliseconds",
+      options: { debounceMilliseconds: 1 },
+    },
+    {
+      name: "with options: debounce milliseconds for columnVisibility",
+      options: { debounceMilliseconds: { columnVisibility: 1 } },
+    },
+    {
+      name: "with options: custom param name, default value, debounce",
+      options: {
+        paramNames: { columnVisibility: "COLUMN_VISIBILITY" },
+        defaultValues: { columnVisibility: { id: true } },
+        debounceMilliseconds: 1,
+      },
+    },
+  ])("%s", ({ options }) => {
+    const paramName =
+      typeof options?.paramNames?.columnVisibility === "function"
+        ? options.paramNames.columnVisibility("columnVisibility")
+        : options?.paramNames?.columnVisibility || "columnVisibility";
+
+    const defaultValue: State["columnVisibility"] =
+      options?.defaultValues?.columnVisibility ??
+      defaultDefaultColumnVisibility;
+
+    const debounceMilliseconds =
+      options?.debounceMilliseconds !== undefined
+        ? typeof options.debounceMilliseconds === "object"
+          ? options.debounceMilliseconds.columnVisibility
+          : options.debounceMilliseconds
+        : undefined;
+
+    test("basic", () => {
+      const { result, rerender: resultRerender } = renderHook(() => {
+        const stateAndOnChanges = useTableSearchParams(mockRouter, options);
+        return useReactTable({
+          columns: [{ id: "id" }, { id: "name" }],
+          data: [],
+          getCoreRowModel: getCoreRowModel(),
+          ...stateAndOnChanges,
+        });
+      });
+      const rerender = () => {
+        if (debounceMilliseconds) {
+          vi.advanceTimersByTime(debounceMilliseconds);
+        }
+        resultRerender();
+      };
+
+      const encoder = options?.encoders?.columnVisibility;
+
+      // initial state
+      const wantInitialState = defaultValue;
+      expect(
+        extractFalseProperties(result.current.getState().columnVisibility),
+      ).toEqual(extractFalseProperties(wantInitialState));
+      expect(mockRouter.query).toEqual({});
+
+      // toggle first column (id)
+      act(() => result.current.getColumn("id")?.toggleVisibility());
+      rerender();
+      const wantToggledFirstColumnState = toggleColumnVisibilityState(
+        wantInitialState,
+        "id",
+      );
+      expect(
+        extractFalseProperties(result.current.getState().columnVisibility),
+      ).toEqual(extractFalseProperties(wantToggledFirstColumnState));
+      expect(mockRouter.query).toEqual(
+        encoder?.(wantToggledFirstColumnState) ?? {
+          [paramName]: defaultEncoder(wantToggledFirstColumnState),
+        },
+      );
+
+      // toggle second column (name)
+      act(() => result.current.getColumn("name")?.toggleVisibility());
+      rerender();
+      const wantRetoggledFirstColumnState = toggleColumnVisibilityState(
+        wantToggledFirstColumnState,
+        "name",
+      );
+      expect(
+        extractFalseProperties(result.current.getState().columnVisibility),
+      ).toEqual(extractFalseProperties(wantRetoggledFirstColumnState));
+      expect(mockRouter.query).toEqual(
+        encoder?.(wantRetoggledFirstColumnState) ?? {
+          [paramName]: defaultEncoder(wantRetoggledFirstColumnState),
+        },
+      );
+
+      // toggle first column (id)
+      act(() => result.current.getColumn("id")?.toggleVisibility());
+      rerender();
+      const wantToggledSecondColumnState = toggleColumnVisibilityState(
+        wantRetoggledFirstColumnState,
+        "id",
+      );
+      expect(
+        extractFalseProperties(result.current.getState().columnVisibility),
+      ).toEqual(extractFalseProperties(wantToggledSecondColumnState));
+      expect(mockRouter.query).toEqual(
+        encoder?.(wantToggledSecondColumnState) ?? {
+          [paramName]:
+            Object.keys(wantToggledSecondColumnState).length === 0
+              ? noneStringForCustomDefaultValue
+              : defaultEncoder(wantToggledSecondColumnState),
+        },
+      );
+
+      // toggle second column (name)
+      act(() => result.current.getColumn("name")?.toggleVisibility());
+      rerender();
+      const wantRetoggledSecondColumnState = toggleColumnVisibilityState(
+        wantToggledSecondColumnState,
+        "name",
+      );
+      expect(
+        extractFalseProperties(result.current.getState().columnVisibility),
+      ).toEqual(extractFalseProperties(wantRetoggledSecondColumnState));
+      expect(mockRouter.query).toEqual(
+        encoder?.(wantRetoggledSecondColumnState) ?? {},
+      );
+    });
+  });
+});

--- a/packages/tanstack-table-search-params/src/tests/next-pages-router/onStateChange.test.ts
+++ b/packages/tanstack-table-search-params/src/tests/next-pages-router/onStateChange.test.ts
@@ -56,6 +56,7 @@ describe("onStateChange", () => {
           columnFilters: "COLUMN_FILTERS",
           columnOrder: "COLUMN_ORDER",
           rowSelection: "ROW_SELECTION",
+          columnVisibility: "COLUMN_VISIBILITY",
           pagination: {
             pageIndex: "PAGE_INDEX",
             pageSize: "PAGE_SIZE",
@@ -72,6 +73,7 @@ describe("onStateChange", () => {
           columnFilters: (key) => `userTable-${key}`,
           columnOrder: (key) => `userTable-${key}`,
           rowSelection: (key) => `userTable-${key}`,
+          columnVisibility: (key) => `userTable-${key}`,
           pagination: ({ pageIndex, pageSize }) => ({
             pageIndex: `userTable-${pageIndex}`,
             pageSize: `userTable-${pageSize}`,
@@ -97,6 +99,9 @@ describe("onStateChange", () => {
           }),
           rowSelection: (rowSelection) => ({
             rowSelection: JSON.stringify(rowSelection),
+          }),
+          columnVisibility: (columnVisibility) => ({
+            columnVisibility: JSON.stringify(columnVisibility),
           }),
           pagination: (pagination) => ({
             pageIndex: JSON.stringify(pagination.pageIndex),
@@ -124,6 +129,10 @@ describe("onStateChange", () => {
             query["rowSelection"]
               ? JSON.parse(query["rowSelection"] as string)
               : query["rowSelection"],
+          columnVisibility: (query) =>
+            query["columnVisibility"]
+              ? JSON.parse(query["columnVisibility"] as string)
+              : query["columnVisibility"],
           pagination: (query) => ({
             pageIndex: query["pageIndex"]
               ? JSON.parse(query["pageIndex"] as string)
@@ -154,6 +163,9 @@ describe("onStateChange", () => {
           rowSelection: (rowSelection) => ({
             "userTable-rowSelection": JSON.stringify(rowSelection),
           }),
+          columnVisibility: (columnVisibility) => ({
+            "userTable-columnVisibility": JSON.stringify(columnVisibility),
+          }),
           pagination: (pagination) => ({
             "userTable-pageIndex": JSON.stringify(pagination.pageIndex),
             "userTable-pageSize": JSON.stringify(pagination.pageSize),
@@ -180,6 +192,10 @@ describe("onStateChange", () => {
             query["userTable-rowSelection"]
               ? JSON.parse(query["userTable-rowSelection"] as string)
               : query["userTable-rowSelection"],
+          columnVisibility: (query) =>
+            query["userTable-columnVisibility"]
+              ? JSON.parse(query["userTable-columnVisibility"] as string)
+              : query["userTable-columnVisibility"],
           pagination: (query) => ({
             pageIndex: query["userTable-pageIndex"]
               ? JSON.parse(query["userTable-pageIndex"] as string)
@@ -223,6 +239,13 @@ describe("onStateChange", () => {
                 "true",
               ]),
             ),
+          columnVisibility: (columnVisibility) =>
+            Object.fromEntries(
+              Object.entries(columnVisibility).map(([id, value]) => [
+                `columnVisibility.${id}`,
+                value ? "true" : "false",
+              ]),
+            ),
           pagination: (pagination) => ({
             pagination: JSON.stringify(pagination),
           }),
@@ -252,6 +275,15 @@ describe("onStateChange", () => {
                 .filter(([key]) => key.startsWith("rowSelection."))
                 .map(([key]) => [key.replace("rowSelection.", ""), true]),
             ),
+          columnVisibility: (query) =>
+            Object.fromEntries(
+              Object.entries(query)
+                .filter(([key]) => key.startsWith("columnVisibility."))
+                .map(([key, value]) => [
+                  key.replace("columnVisibility.", ""),
+                  value === "true",
+                ]),
+            ),
           pagination: (query) =>
             query["pagination"]
               ? JSON.parse(query["pagination"] as string)
@@ -268,6 +300,7 @@ describe("onStateChange", () => {
           columnFilters: [{ id: "custom", value: "default" }],
           columnOrder: ["name", "id"],
           rowSelection: { "1": true },
+          columnVisibility: { id: false },
           pagination: { pageIndex: 3, pageSize: 25 },
         },
       },
@@ -285,6 +318,7 @@ describe("onStateChange", () => {
           columnFilters: "COLUMN_FILTERS",
           columnOrder: "COLUMN_ORDER",
           rowSelection: "ROW_SELECTION",
+          columnVisibility: "COLUMN_VISIBILITY",
           pagination: { pageIndex: "PAGE_INDEX", pageSize: "PAGE_SIZE" },
         },
         defaultValues: {
@@ -293,6 +327,7 @@ describe("onStateChange", () => {
           columnFilters: [{ id: "custom", value: "default" }],
           columnOrder: ["name", "id"],
           rowSelection: { "1": true },
+          columnVisibility: { id: false },
           pagination: { pageIndex: 3, pageSize: 25 },
         },
       },
@@ -306,6 +341,7 @@ describe("onStateChange", () => {
         | "columnFilters"
         | "columnOrder"
         | "rowSelection"
+        | "columnVisibility"
       >,
     ) => {
       const paramName = options?.paramNames?.[name];
@@ -319,6 +355,7 @@ describe("onStateChange", () => {
     const columnFiltersParamName = getParamName("columnFilters");
     const columnOrderParamName = getParamName("columnOrder");
     const rowSelectionParamName = getParamName("rowSelection");
+    const columnVisibilityParamName = getParamName("columnVisibility");
     const paginationParamName =
       typeof options?.paramNames?.pagination === "function"
         ? options.paramNames.pagination({
@@ -346,6 +383,8 @@ describe("onStateChange", () => {
     const defaultColumnFilters = options?.defaultValues?.columnFilters ?? [];
     const defaultColumnOrder = options?.defaultValues?.columnOrder ?? [];
     const defaultRowSelection = options?.defaultValues?.rowSelection ?? {};
+    const defaultColumnVisibility =
+      options?.defaultValues?.columnVisibility ?? {};
     const defaultPagination = options?.defaultValues?.pagination ?? {
       pageIndex: 0,
       pageSize: 10,
@@ -358,6 +397,7 @@ describe("onStateChange", () => {
       columnFilters: defaultColumnFilters,
       columnOrder: defaultColumnOrder,
       rowSelection: defaultRowSelection,
+      columnVisibility: defaultColumnVisibility,
       pagination: defaultPagination,
     };
 
@@ -372,6 +412,7 @@ describe("onStateChange", () => {
       columnFilters: [{ id: "column1", value: "value" }],
       columnOrder: ["column1"],
       rowSelection: { row1: true },
+      columnVisibility: { column1: false },
       pagination: { pageIndex: 1, pageSize: 20 },
     };
 
@@ -400,6 +441,9 @@ describe("onStateChange", () => {
       }),
       ...(options?.encoders?.rowSelection?.(newState.rowSelection) ?? {
         [rowSelectionParamName]: "row1",
+      }),
+      ...(options?.encoders?.columnVisibility?.(newState.columnVisibility) ?? {
+        [columnVisibilityParamName]: "column1",
       }),
       ...(options?.encoders?.pagination?.(newState.pagination) ?? {
         [paginationParamName.pageIndex]: `${newState.pagination.pageIndex + 1}`,
@@ -438,6 +482,12 @@ describe("onStateChange", () => {
       ...(options?.encoders?.rowSelection?.({}) ?? {
         [rowSelectionParamName]:
           Object.keys(defaultRowSelection).length > 0
+            ? noneStringForCustomDefaultValue
+            : undefined,
+      }),
+      ...(options?.encoders?.columnVisibility?.(defaultColumnVisibility) ?? {
+        [columnVisibilityParamName]:
+          Object.keys(defaultColumnVisibility).length > 0
             ? noneStringForCustomDefaultValue
             : undefined,
       }),

--- a/packages/tanstack-table-search-params/src/tests/onStateChange.test.ts
+++ b/packages/tanstack-table-search-params/src/tests/onStateChange.test.ts
@@ -54,6 +54,7 @@ describe("onStateChange", () => {
           columnFilters: "COLUMN_FILTERS",
           columnOrder: "COLUMN_ORDER",
           rowSelection: "ROW_SELECTION",
+          columnVisibility: "COLUMN_VISIBILITY",
           pagination: {
             pageIndex: "PAGE_INDEX",
             pageSize: "PAGE_SIZE",
@@ -70,6 +71,7 @@ describe("onStateChange", () => {
           columnFilters: (key) => `userTable-${key}`,
           columnOrder: (key) => `userTable-${key}`,
           rowSelection: (key) => `userTable-${key}`,
+          columnVisibility: (key) => `userTable-${key}`,
           pagination: ({ pageIndex, pageSize }) => ({
             pageIndex: `userTable-${pageIndex}`,
             pageSize: `userTable-${pageSize}`,
@@ -95,6 +97,9 @@ describe("onStateChange", () => {
           }),
           rowSelection: (rowSelection) => ({
             rowSelection: JSON.stringify(rowSelection),
+          }),
+          columnVisibility: (columnVisibility) => ({
+            columnVisibility: JSON.stringify(columnVisibility),
           }),
           pagination: (pagination) => ({
             pageIndex: JSON.stringify(pagination.pageIndex),
@@ -122,6 +127,10 @@ describe("onStateChange", () => {
             query["rowSelection"]
               ? JSON.parse(query["rowSelection"] as string)
               : query["rowSelection"],
+          columnVisibility: (query) =>
+            query["columnVisibility"]
+              ? JSON.parse(query["columnVisibility"] as string)
+              : query["columnVisibility"],
           pagination: (query) => ({
             pageIndex: query["pageIndex"]
               ? JSON.parse(query["pageIndex"] as string)
@@ -152,6 +161,9 @@ describe("onStateChange", () => {
           rowSelection: (rowSelection) => ({
             "userTable-rowSelection": JSON.stringify(rowSelection),
           }),
+          columnVisibility: (columnVisibility) => ({
+            "userTable-columnVisibility": JSON.stringify(columnVisibility),
+          }),
           pagination: (pagination) => ({
             "userTable-pageIndex": JSON.stringify(pagination.pageIndex),
             "userTable-pageSize": JSON.stringify(pagination.pageSize),
@@ -178,6 +190,10 @@ describe("onStateChange", () => {
             query["userTable-rowSelection"]
               ? JSON.parse(query["userTable-rowSelection"] as string)
               : query["userTable-rowSelection"],
+          columnVisibility: (query) =>
+            query["userTable-columnVisibility"]
+              ? JSON.parse(query["userTable-columnVisibility"] as string)
+              : query["userTable-columnVisibility"],
           pagination: (query) => ({
             pageIndex: query["userTable-pageIndex"]
               ? JSON.parse(query["userTable-pageIndex"] as string)
@@ -221,6 +237,13 @@ describe("onStateChange", () => {
                 "true",
               ]),
             ),
+          columnVisibility: (columnVisibility) =>
+            Object.fromEntries(
+              Object.entries(columnVisibility).map(([id, value]) => [
+                `columnVisibility.${id}`,
+                value ? "true" : "false",
+              ]),
+            ),
           pagination: (pagination) => ({
             pagination: JSON.stringify(pagination),
           }),
@@ -250,6 +273,15 @@ describe("onStateChange", () => {
                 .filter(([key]) => key.startsWith("rowSelection."))
                 .map(([key]) => [key.replace("rowSelection.", ""), true]),
             ),
+          columnVisibility: (query) =>
+            Object.fromEntries(
+              Object.entries(query)
+                .filter(([key]) => key.startsWith("columnVisibility."))
+                .map(([key, value]) => [
+                  key.replace("columnVisibility.", ""),
+                  value === "true",
+                ]),
+            ),
           pagination: (query) =>
             query["pagination"]
               ? JSON.parse(query["pagination"] as string)
@@ -266,6 +298,7 @@ describe("onStateChange", () => {
           columnFilters: [{ id: "custom", value: "default" }],
           columnOrder: ["name", "id"],
           rowSelection: { "1": true },
+          columnVisibility: { id: false },
           pagination: { pageIndex: 3, pageSize: 25 },
         },
       },
@@ -283,6 +316,7 @@ describe("onStateChange", () => {
           columnFilters: "COLUMN_FILTERS",
           columnOrder: "COLUMN_ORDER",
           rowSelection: "ROW_SELECTION",
+          columnVisibility: "COLUMN_VISIBILITY",
           pagination: { pageIndex: "PAGE_INDEX", pageSize: "PAGE_SIZE" },
         },
         defaultValues: {
@@ -291,6 +325,7 @@ describe("onStateChange", () => {
           columnFilters: [{ id: "custom", value: "default" }],
           columnOrder: ["name", "id"],
           rowSelection: { "1": true },
+          columnVisibility: { id: false },
           pagination: { pageIndex: 3, pageSize: 25 },
         },
       },
@@ -304,6 +339,7 @@ describe("onStateChange", () => {
         | "columnFilters"
         | "columnOrder"
         | "rowSelection"
+        | "columnVisibility"
       >,
     ) => {
       const paramName = options?.paramNames?.[name];
@@ -317,6 +353,7 @@ describe("onStateChange", () => {
     const columnFiltersParamName = getParamName("columnFilters");
     const columnOrderParamName = getParamName("columnOrder");
     const rowSelectionParamName = getParamName("rowSelection");
+    const columnVisibilityParamName = getParamName("columnVisibility");
     const paginationParamName =
       typeof options?.paramNames?.pagination === "function"
         ? options.paramNames.pagination({
@@ -350,6 +387,8 @@ describe("onStateChange", () => {
     const defaultColumnFilters = options?.defaultValues?.columnFilters ?? [];
     const defaultColumnOrder = options?.defaultValues?.columnOrder ?? [];
     const defaultRowSelection = options?.defaultValues?.rowSelection ?? {};
+    const defaultColumnVisibility =
+      options?.defaultValues?.columnVisibility ?? {};
     const defaultPagination = options?.defaultValues?.pagination ?? {
       pageIndex: 0,
       pageSize: 10,
@@ -362,6 +401,7 @@ describe("onStateChange", () => {
       columnFilters: defaultColumnFilters,
       columnOrder: defaultColumnOrder,
       rowSelection: defaultRowSelection,
+      columnVisibility: defaultColumnVisibility,
       pagination: defaultPagination,
     };
 
@@ -376,6 +416,7 @@ describe("onStateChange", () => {
       columnFilters: [{ id: "column1", value: "value" }],
       columnOrder: ["column1"],
       rowSelection: { row1: true },
+      columnVisibility: { column1: false },
       pagination: { pageIndex: 1, pageSize: 20 },
     };
 
@@ -405,6 +446,9 @@ describe("onStateChange", () => {
       }),
       ...(options?.encoders?.rowSelection?.(newState.rowSelection) ?? {
         [rowSelectionParamName]: "row1",
+      }),
+      ...(options?.encoders?.columnVisibility?.(newState.columnVisibility) ?? {
+        [columnVisibilityParamName]: "column1",
       }),
       ...(options?.encoders?.pagination?.(newState.pagination) ?? {
         [paginationParamName.pageIndex]: `${newState.pagination.pageIndex + 1}`,
@@ -443,6 +487,12 @@ describe("onStateChange", () => {
       ...(options?.encoders?.rowSelection?.({}) ?? {
         [rowSelectionParamName]:
           Object.keys(defaultRowSelection).length > 0
+            ? noneStringForCustomDefaultValue
+            : undefined,
+      }),
+      ...(options?.encoders?.columnVisibility?.(defaultColumnVisibility) ?? {
+        [columnVisibilityParamName]:
+          Object.keys(defaultColumnVisibility).length > 0
             ? noneStringForCustomDefaultValue
             : undefined,
       }),

--- a/packages/tanstack-table-search-params/src/tests/rowSelection.test.ts
+++ b/packages/tanstack-table-search-params/src/tests/rowSelection.test.ts
@@ -8,10 +8,7 @@ import {
   encodeRowSelection as defaultEncoder,
 } from "../encoder-decoder/rowSelection";
 import { useTestRouter } from "./testRouter";
-
-const typedObjectEntries = <K extends string | number | symbol, V>(
-  object: Record<K, V>,
-): [K, V][] => Object.entries(object) as [K, V][];
+import { typedObjectEntries } from "./utils";
 
 type RowSelection = State["rowSelection"];
 

--- a/packages/tanstack-table-search-params/src/tests/utils.ts
+++ b/packages/tanstack-table-search-params/src/tests/utils.ts
@@ -1,0 +1,3 @@
+export const typedObjectEntries = <K extends PropertyKey, V>(
+  object: Record<K, V>,
+): [K, V][] => Object.entries(object) as [K, V][];

--- a/packages/tanstack-table-search-params/src/useColumnVisibility.ts
+++ b/packages/tanstack-table-search-params/src/useColumnVisibility.ts
@@ -1,0 +1,133 @@
+import { functionalUpdate, type OnChangeFn } from "@tanstack/react-table";
+import { useCallback, useMemo } from "react";
+import { PARAM_NAMES, type State } from ".";
+import {
+  decodeColumnVisibility,
+  encodeColumnVisibility,
+} from "./encoder-decoder/columnVisibility";
+import type { Query, Router } from "./types";
+import { updateQuery } from "./updateQuery";
+import { useDebounce } from "./useDebounce";
+import type { ExtractSpecificStateOptions } from "./utils";
+
+type Props = {
+  router: Router;
+  options?: ExtractSpecificStateOptions<"columnVisibility">;
+};
+
+type Returns = {
+  columnVisibility: State["columnVisibility"];
+  columnVisibilityEncoder: (
+    columnVisibility: State["columnVisibility"],
+  ) => Query;
+  onColumnVisibilityChange: OnChangeFn<State["columnVisibility"]>;
+};
+
+export const useColumnVisibility = ({ router, options }: Props): Returns => {
+  const paramName =
+    (typeof options?.paramName === "function"
+      ? options?.paramName(PARAM_NAMES.COLUMN_VISIBILITY)
+      : options?.paramName) || PARAM_NAMES.COLUMN_VISIBILITY;
+
+  const stringDefaultColumnVisibility =
+    options?.defaultValue && JSON.stringify(options?.defaultValue);
+
+  const uncustomisedColumnVisibility = useMemo(
+    () =>
+      decodeColumnVisibility(router.query[paramName], {
+        defaultValue:
+          stringDefaultColumnVisibility === undefined
+            ? undefined
+            : JSON.parse(stringDefaultColumnVisibility),
+      }),
+    [router.query[paramName], paramName, stringDefaultColumnVisibility],
+  );
+
+  // If `router.query` is included in the dependency array,
+  // `columnVisibility` will always be regenerated.
+  // To prevent this, use `JSON.stringify` and `JSON.parse`
+  // when utilizing a custom decoder.
+  const isCustomDecoder = !!options?.decoder;
+  const stringCustomColumnVisibility = options?.decoder?.(router.query)
+    ? JSON.stringify(options.decoder(router.query))
+    : "";
+  const _columnVisibility = useMemo(
+    () =>
+      isCustomDecoder
+        ? stringCustomColumnVisibility === ""
+          ? {}
+          : JSON.parse(stringCustomColumnVisibility)
+        : uncustomisedColumnVisibility,
+    [
+      stringCustomColumnVisibility,
+      uncustomisedColumnVisibility,
+      isCustomDecoder,
+    ],
+  );
+
+  const columnVisibilityEncoder = useCallback(
+    (columnVisibility: State["columnVisibility"]) =>
+      options?.encoder
+        ? options.encoder(columnVisibility)
+        : {
+            [paramName]: encodeColumnVisibility(columnVisibility, {
+              defaultValue:
+                stringDefaultColumnVisibility === undefined
+                  ? undefined
+                  : JSON.parse(stringDefaultColumnVisibility),
+            }),
+          },
+    [paramName, options?.encoder, stringDefaultColumnVisibility],
+  );
+
+  const updateColumnVisibilityQuery = useCallback(
+    (newColumnVisibility: State["columnVisibility"]) =>
+      updateQuery({
+        oldQuery: columnVisibilityEncoder(_columnVisibility),
+        newQuery: columnVisibilityEncoder(newColumnVisibility),
+        router,
+      }),
+    [router, columnVisibilityEncoder, _columnVisibility],
+  );
+
+  const [debouncedColumnVisibility, setDebouncedColumnVisibility] = useDebounce(
+    {
+      stateValue: _columnVisibility,
+      updateQuery: updateColumnVisibilityQuery,
+      milliseconds: options?.debounceMilliseconds,
+    },
+  );
+
+  const columnVisibility = useMemo(
+    () =>
+      options?.debounceMilliseconds === undefined
+        ? _columnVisibility
+        : debouncedColumnVisibility,
+    [
+      _columnVisibility,
+      debouncedColumnVisibility,
+      options?.debounceMilliseconds,
+    ],
+  );
+
+  return {
+    columnVisibility,
+    columnVisibilityEncoder,
+    onColumnVisibilityChange: useCallback(
+      async (updater) => {
+        const newColumnVisibility = functionalUpdate(updater, columnVisibility);
+        if (options?.debounceMilliseconds !== undefined) {
+          setDebouncedColumnVisibility(newColumnVisibility);
+          return;
+        }
+        await updateColumnVisibilityQuery(newColumnVisibility);
+      },
+      [
+        columnVisibility,
+        options?.debounceMilliseconds,
+        updateColumnVisibilityQuery,
+        setDebouncedColumnVisibility,
+      ],
+    ),
+  };
+};


### PR DESCRIPTION
Add support TanStack Table's [`columnVisibility`](https://tanstack.com/table/v8/docs/guide/column-visibility) state.

Fixes https://github.com/taro-28/tanstack-table-search-params/issues/604

https://github.com/user-attachments/assets/59f674e5-f7dd-4abc-af81-ea5ef094fd20


