### PR TITLE
feat: add per-state `enabled` option to selectively sync table state with URL params

### DIFF
--- a/examples/next-pages-router/src/pages/index.tsx
+++ b/examples/next-pages-router/src/pages/index.tsx
@@ -17,7 +17,9 @@ export default function Basic() {
   const data = useUserData();
 
   const router = useRouter();
-  const stateAndOnChanges = useTableSearchParams(router);
+  const stateAndOnChanges = useTableSearchParams(router, {
+    enabled: { globalFilter: false, sorting: false },
+  });
 
   const table = useReactTable({
     data,

--- a/packages/tanstack-table-search-params/README.md
+++ b/packages/tanstack-table-search-params/README.md
@@ -217,6 +217,7 @@ The `useTableSearchParams` hook primarily does the following two things:
 - [🪄 Custom default value](#custom-default-value)
 - [🔢 Custom encoder/decoder](#custom-encoder-decoder)
 - [⏱️ Debounce](#debounce)
+- [☑️ Enable/Disable](#enable-disable)
 
 <h2 id="custom-query-param-name">🏷️ Custom query param name</h2>
 
@@ -363,6 +364,18 @@ const stateAndOnChanges = useTableSearchParams(router, {
 });
 ```
 
+<h2 id="enable-disable">⚙️ Enable/Disable</h2>
+
+You can enable/disable the synchronization of a query parameter.
+All states are enabled by default.
+
+```tsx
+const stateAndOnChanges = useTableSearchParams(router, {
+  // Disable synchronization of sorting
+  enabled: { sorting: false },
+});
+```
+
 ## 💬 Troubleshooting
 
 ### Q. The page transitions every time the search params change
@@ -425,7 +438,6 @@ List of supported TanStack table states
 ## Roadmap
 
 - [ ] Support other table states
-- [ ] Disable specific state
 - [ ] Add `onChangeXxxQuery` option
 
 ## License

--- a/packages/tanstack-table-search-params/src/tests/columnFilters.test.ts
+++ b/packages/tanstack-table-search-params/src/tests/columnFilters.test.ts
@@ -95,6 +95,10 @@ describe("columnFilters", () => {
       options: { debounceMilliseconds: { columnFilters: 1 } },
     },
     {
+      name: "with options: enabled false",
+      options: { enabled: { columnFilters: false } },
+    },
+    {
       name: "with options: custom param name, default value, debounce",
       options: {
         paramNames: { columnFilters: "COLUMN_FILTERS" },
@@ -117,6 +121,8 @@ describe("columnFilters", () => {
           ? options.debounceMilliseconds.columnFilters
           : options.debounceMilliseconds
         : undefined;
+
+    const enabled = options?.enabled?.columnFilters ?? true;
 
     test("single column: string value", () => {
       const { result: routerResult, rerender: routerRerender } = renderHook(
@@ -159,12 +165,16 @@ describe("columnFilters", () => {
         { id: "name", value: "J" },
       ]);
       expect(routerResult.current.query).toEqual(
-        options?.encoders?.columnFilters?.([{ id: "name", value: "J" }]) ?? {
-          [paramName]:
-            defaultColumnFilters.length === 0
-              ? "name.%22J%22"
-              : "custom.%22default%22,name.%22J%22",
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.columnFilters?.([
+              { id: "name", value: "J" },
+            ]) ?? {
+              [paramName]:
+                defaultColumnFilters.length === 0
+                  ? "name.%22J%22"
+                  : "custom.%22default%22,name.%22J%22",
+            }),
       );
 
       // reset
@@ -173,7 +183,7 @@ describe("columnFilters", () => {
       });
       rerender();
       expect(routerResult.current.query).toEqual(
-        options?.encoders?.columnFilters?.([]) ?? {},
+        !enabled ? {} : (options?.encoders?.columnFilters?.([]) ?? {}),
       );
       expect(result.current.getState().columnFilters).toEqual(
         defaultColumnFilters,
@@ -229,14 +239,16 @@ describe("columnFilters", () => {
         { id: "age", value: [30, 40] },
       ]);
       expect(routerResult.current.query).toEqual(
-        options?.encoders?.columnFilters?.([
-          { id: "age", value: [30, 40] },
-        ]) ?? {
-          [paramName]:
-            defaultColumnFilters.length === 0
-              ? "age.%5B30%2C40%5D"
-              : "custom.%22default%22,age.%5B30%2C40%5D",
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.columnFilters?.([
+              { id: "age", value: [30, 40] },
+            ]) ?? {
+              [paramName]:
+                defaultColumnFilters.length === 0
+                  ? "age.%5B30%2C40%5D"
+                  : "custom.%22default%22,age.%5B30%2C40%5D",
+            }),
       );
 
       // reset
@@ -248,7 +260,7 @@ describe("columnFilters", () => {
         defaultColumnFilters,
       );
       expect(routerResult.current.query).toEqual(
-        options?.encoders?.columnFilters?.([]) ?? {},
+        !enabled ? {} : (options?.encoders?.columnFilters?.([]) ?? {}),
       );
     });
 
@@ -302,12 +314,16 @@ describe("columnFilters", () => {
         { id: "name", value: "J" },
       ]);
       expect(routerResult.current.query).toEqual(
-        options?.encoders?.columnFilters?.([{ id: "name", value: "J" }]) ?? {
-          [paramName]:
-            defaultColumnFilters.length === 0
-              ? "name.%22J%22"
-              : "custom.%22default%22,name.%22J%22",
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.columnFilters?.([
+              { id: "name", value: "J" },
+            ]) ?? {
+              [paramName]:
+                defaultColumnFilters.length === 0
+                  ? "name.%22J%22"
+                  : "custom.%22default%22,name.%22J%22",
+            }),
       );
 
       // set array value for column filter
@@ -331,14 +347,16 @@ describe("columnFilters", () => {
         { id: "age", value: [30, 40] },
       ]);
       expect(routerResult.current.query).toEqual(
-        options?.encoders?.columnFilters?.([
-          { id: "age", value: [30, 40] },
-        ]) ?? {
-          [paramName]:
-            defaultColumnFilters.length === 0
-              ? "age.%5B30%2C40%5D"
-              : "custom.%22default%22,age.%5B30%2C40%5D",
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.columnFilters?.([
+              { id: "age", value: [30, 40] },
+            ]) ?? {
+              [paramName]:
+                defaultColumnFilters.length === 0
+                  ? "age.%5B30%2C40%5D"
+                  : "custom.%22default%22,age.%5B30%2C40%5D",
+            }),
       );
 
       act(() => {
@@ -349,7 +367,7 @@ describe("columnFilters", () => {
         defaultColumnFilters,
       );
       expect(routerResult.current.query).toEqual(
-        options?.encoders?.columnFilters?.([]) ?? {},
+        !enabled ? {} : (options?.encoders?.columnFilters?.([]) ?? {}),
       );
     });
   });

--- a/packages/tanstack-table-search-params/src/tests/columnOrder.test.ts
+++ b/packages/tanstack-table-search-params/src/tests/columnOrder.test.ts
@@ -91,6 +91,10 @@ describe("columnOrder", () => {
       options: { debounceMilliseconds: { columnOrder: 1 } },
     },
     {
+      name: "with options: enabled false",
+      options: { enabled: { columnOrder: false } },
+    },
+    {
       name: "with options: custom param name, default value, debounce",
       options: {
         paramNames: { columnOrder: "COLUMN_ORDER" },
@@ -113,6 +117,8 @@ describe("columnOrder", () => {
           ? options.debounceMilliseconds.columnOrder
           : options.debounceMilliseconds
         : undefined;
+
+    const enabled = options?.enabled?.columnOrder ?? true;
 
     test("single column: string value", () => {
       const { result: routerResult, rerender: routerRerender } = renderHook(
@@ -157,9 +163,12 @@ describe("columnOrder", () => {
 
       expect(result.current.getState().columnOrder).toEqual(reversed);
       expect(routerResult.current.query).toEqual(
-        options?.encoders?.columnOrder?.(reversed) ?? {
-          [paramName]: defaultColumnOrder.length === 0 ? "name,id" : "id,name",
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.columnOrder?.(reversed) ?? {
+              [paramName]:
+                defaultColumnOrder.length === 0 ? "name,id" : "id,name",
+            }),
       );
 
       // reset
@@ -169,12 +178,14 @@ describe("columnOrder", () => {
       rerender();
 
       expect(routerResult.current.query).toEqual(
-        options?.encoders?.columnOrder?.(defaultColumnOrder) ?? {
-          [paramName]:
-            defaultColumnOrder.length > 0
-              ? noneStringForCustomDefaultValue
-              : undefined,
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.columnOrder?.(defaultColumnOrder) ?? {
+              [paramName]:
+                defaultColumnOrder.length > 0
+                  ? noneStringForCustomDefaultValue
+                  : undefined,
+            }),
       );
       expect(result.current.getState().columnOrder).toEqual([]);
     });

--- a/packages/tanstack-table-search-params/src/tests/columnVisibility.test.ts
+++ b/packages/tanstack-table-search-params/src/tests/columnVisibility.test.ts
@@ -116,6 +116,10 @@ describe("columnVisibility", () => {
       options: { debounceMilliseconds: { columnVisibility: 1 } },
     },
     {
+      name: "with options: enabled false",
+      options: { enabled: { columnVisibility: false } },
+    },
+    {
       name: "with options: custom param name, default value, debounce",
       options: {
         paramNames: { columnVisibility: "COLUMN_VISIBILITY" },
@@ -139,6 +143,8 @@ describe("columnVisibility", () => {
           ? options.debounceMilliseconds.columnVisibility
           : options.debounceMilliseconds
         : undefined;
+
+    const enabled = options?.enabled?.columnVisibility ?? true;
 
     test("basic", () => {
       const { result: routerResult, rerender: routerRerender } = renderHook(
@@ -184,9 +190,11 @@ describe("columnVisibility", () => {
         extractFalseProperties(result.current.getState().columnVisibility),
       ).toEqual(extractFalseProperties(wantToggledFirstColumnState));
       expect(routerResult.current.query).toEqual(
-        encoder?.(wantToggledFirstColumnState) ?? {
-          [paramName]: defaultEncoder(wantToggledFirstColumnState),
-        },
+        !enabled
+          ? {}
+          : (encoder?.(wantToggledFirstColumnState) ?? {
+              [paramName]: defaultEncoder(wantToggledFirstColumnState),
+            }),
       );
 
       // toggle second column (name)
@@ -200,9 +208,11 @@ describe("columnVisibility", () => {
         extractFalseProperties(result.current.getState().columnVisibility),
       ).toEqual(extractFalseProperties(wantRetoggledFirstColumnState));
       expect(routerResult.current.query).toEqual(
-        encoder?.(wantRetoggledFirstColumnState) ?? {
-          [paramName]: defaultEncoder(wantRetoggledFirstColumnState),
-        },
+        !enabled
+          ? {}
+          : (encoder?.(wantRetoggledFirstColumnState) ?? {
+              [paramName]: defaultEncoder(wantRetoggledFirstColumnState),
+            }),
       );
 
       // toggle first column (id)
@@ -216,12 +226,14 @@ describe("columnVisibility", () => {
         extractFalseProperties(result.current.getState().columnVisibility),
       ).toEqual(extractFalseProperties(wantToggledSecondColumnState));
       expect(routerResult.current.query).toEqual(
-        encoder?.(wantToggledSecondColumnState) ?? {
-          [paramName]:
-            Object.keys(wantToggledSecondColumnState).length === 0
-              ? noneStringForCustomDefaultValue
-              : defaultEncoder(wantToggledSecondColumnState),
-        },
+        !enabled
+          ? {}
+          : (encoder?.(wantToggledSecondColumnState) ?? {
+              [paramName]:
+                Object.keys(wantToggledSecondColumnState).length === 0
+                  ? noneStringForCustomDefaultValue
+                  : defaultEncoder(wantToggledSecondColumnState),
+            }),
       );
 
       // toggle second column (name)
@@ -235,7 +247,7 @@ describe("columnVisibility", () => {
         extractFalseProperties(result.current.getState().columnVisibility),
       ).toEqual(extractFalseProperties(wantRetoggledSecondColumnState));
       expect(routerResult.current.query).toEqual(
-        encoder?.(wantRetoggledSecondColumnState) ?? {},
+        !enabled ? {} : (encoder?.(wantRetoggledSecondColumnState) ?? {}),
       );
     });
   });

--- a/packages/tanstack-table-search-params/src/tests/globalFilter.test.ts
+++ b/packages/tanstack-table-search-params/src/tests/globalFilter.test.ts
@@ -73,6 +73,10 @@ describe("globalFilter", () => {
       options: { debounceMilliseconds: { globalFilter: 1 } },
     },
     {
+      name: "with options: enabled false",
+      options: { enabled: { globalFilter: false } },
+    },
+    {
       name: "with options: custom param name, default value, debounce",
       options: {
         paramNames: { globalFilter: "GLOBAL_FILTER" },
@@ -92,6 +96,8 @@ describe("globalFilter", () => {
           ? options.debounceMilliseconds.globalFilter
           : options.debounceMilliseconds
         : undefined;
+
+    const enabled = options?.enabled?.globalFilter ?? true;
 
     test("basic", () => {
       const { result: routerResult, rerender: routerRerender } = renderHook(
@@ -121,7 +127,9 @@ describe("globalFilter", () => {
         options?.defaultValues?.globalFilter ?? defaultDefaultGlobalFilter;
 
       // initial state
-      expect(result.current.getState().globalFilter).toBe(defaultGlobalFilter);
+      expect(result.current.getState().globalFilter).toBe(
+        !enabled ? undefined : defaultGlobalFilter,
+      );
       expect(routerResult.current.query).toEqual({});
 
       // set
@@ -129,7 +137,11 @@ describe("globalFilter", () => {
       rerender();
       expect(result.current.getState().globalFilter).toBe("John");
       expect(routerResult.current.query).toEqual(
-        options?.encoders?.globalFilter?.("John") ?? { [paramName]: "John" },
+        !enabled
+          ? {}
+          : (options?.encoders?.globalFilter?.("John") ?? {
+              [paramName]: "John",
+            }),
       );
 
       // reset
@@ -138,11 +150,13 @@ describe("globalFilter", () => {
 
       expect(result.current.getState().globalFilter).toBe("");
       expect(routerResult.current.query).toEqual(
-        options?.encoders?.globalFilter?.("") ?? {
-          [paramName]: defaultGlobalFilter
-            ? encodedEmptyStringForGlobalFilterCustomDefaultValue
-            : undefined,
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.globalFilter?.("") ?? {
+              [paramName]: defaultGlobalFilter
+                ? encodedEmptyStringForGlobalFilterCustomDefaultValue
+                : undefined,
+            }),
       );
     });
   });

--- a/packages/tanstack-table-search-params/src/tests/next-pages-router/columnFilters.test.ts
+++ b/packages/tanstack-table-search-params/src/tests/next-pages-router/columnFilters.test.ts
@@ -95,6 +95,10 @@ describe("columnFilters", () => {
       options: { debounceMilliseconds: { columnFilters: 1 } },
     },
     {
+      name: "with options: enabled false",
+      options: { enabled: { columnFilters: false } },
+    },
+    {
       name: "with options: custom param name, default value, debounce",
       options: {
         paramNames: { columnFilters: "COLUMN_FILTERS" },
@@ -117,6 +121,8 @@ describe("columnFilters", () => {
           ? options.debounceMilliseconds.columnFilters
           : options.debounceMilliseconds
         : undefined;
+
+    const enabled = options?.enabled?.columnFilters ?? true;
 
     test("single column: string value", () => {
       const { result, rerender: resultRerender } = renderHook(() => {
@@ -142,7 +148,7 @@ describe("columnFilters", () => {
       expect(result.current.getState().columnFilters).toEqual(
         defaultColumnFilters,
       );
-      expect(mockRouter.query).toEqual({});
+      expect(mockRouter.query).toEqual(!enabled ? {} : {});
 
       // set string value for column filter
       act(() => result.current.getFlatHeaders()[1]?.column.setFilterValue("J"));
@@ -152,12 +158,16 @@ describe("columnFilters", () => {
         { id: "name", value: "J" },
       ]);
       expect(mockRouter.query).toEqual(
-        options?.encoders?.columnFilters?.([{ id: "name", value: "J" }]) ?? {
-          [paramName]:
-            defaultColumnFilters.length === 0
-              ? "name.%22J%22"
-              : "custom.%22default%22,name.%22J%22",
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.columnFilters?.([
+              { id: "name", value: "J" },
+            ]) ?? {
+              [paramName]:
+                defaultColumnFilters.length === 0
+                  ? "name.%22J%22"
+                  : "custom.%22default%22,name.%22J%22",
+            }),
       );
 
       // reset
@@ -166,7 +176,7 @@ describe("columnFilters", () => {
       });
       rerender();
       expect(mockRouter.query).toEqual(
-        options?.encoders?.columnFilters?.([]) ?? {},
+        !enabled ? {} : (options?.encoders?.columnFilters?.([]) ?? {}),
       );
       expect(result.current.getState().columnFilters).toEqual(
         defaultColumnFilters,
@@ -203,7 +213,7 @@ describe("columnFilters", () => {
       expect(result.current.getState().columnFilters).toEqual(
         defaultColumnFilters,
       );
-      expect(mockRouter.query).toEqual({});
+      expect(mockRouter.query).toEqual(!enabled ? {} : {});
 
       // set array value for column filter
       act(() =>
@@ -215,14 +225,16 @@ describe("columnFilters", () => {
         { id: "age", value: [30, 40] },
       ]);
       expect(mockRouter.query).toEqual(
-        options?.encoders?.columnFilters?.([
-          { id: "age", value: [30, 40] },
-        ]) ?? {
-          [paramName]:
-            defaultColumnFilters.length === 0
-              ? "age.%5B30%2C40%5D"
-              : "custom.%22default%22,age.%5B30%2C40%5D",
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.columnFilters?.([
+              { id: "age", value: [30, 40] },
+            ]) ?? {
+              [paramName]:
+                defaultColumnFilters.length === 0
+                  ? "age.%5B30%2C40%5D"
+                  : "custom.%22default%22,age.%5B30%2C40%5D",
+            }),
       );
 
       // reset
@@ -234,7 +246,7 @@ describe("columnFilters", () => {
         defaultColumnFilters,
       );
       expect(mockRouter.query).toEqual(
-        options?.encoders?.columnFilters?.([]) ?? {},
+        !enabled ? {} : (options?.encoders?.columnFilters?.([]) ?? {}),
       );
     });
 
@@ -268,7 +280,7 @@ describe("columnFilters", () => {
       expect(result.current.getState().columnFilters).toEqual(
         defaultColumnFilters,
       );
-      expect(mockRouter.query).toEqual({});
+      expect(mockRouter.query).toEqual(!enabled ? {} : {});
 
       // set string value for column filter
       act(() => {
@@ -281,12 +293,16 @@ describe("columnFilters", () => {
         { id: "name", value: "J" },
       ]);
       expect(mockRouter.query).toEqual(
-        options?.encoders?.columnFilters?.([{ id: "name", value: "J" }]) ?? {
-          [paramName]:
-            defaultColumnFilters.length === 0
-              ? "name.%22J%22"
-              : "custom.%22default%22,name.%22J%22",
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.columnFilters?.([
+              { id: "name", value: "J" },
+            ]) ?? {
+              [paramName]:
+                defaultColumnFilters.length === 0
+                  ? "name.%22J%22"
+                  : "custom.%22default%22,name.%22J%22",
+            }),
       );
 
       // set array value for column filter
@@ -310,14 +326,16 @@ describe("columnFilters", () => {
         { id: "age", value: [30, 40] },
       ]);
       expect(mockRouter.query).toEqual(
-        options?.encoders?.columnFilters?.([
-          { id: "age", value: [30, 40] },
-        ]) ?? {
-          [paramName]:
-            defaultColumnFilters.length === 0
-              ? "age.%5B30%2C40%5D"
-              : "custom.%22default%22,age.%5B30%2C40%5D",
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.columnFilters?.([
+              { id: "age", value: [30, 40] },
+            ]) ?? {
+              [paramName]:
+                defaultColumnFilters.length === 0
+                  ? "age.%5B30%2C40%5D"
+                  : "custom.%22default%22,age.%5B30%2C40%5D",
+            }),
       );
 
       act(() => {
@@ -328,7 +346,7 @@ describe("columnFilters", () => {
         defaultColumnFilters,
       );
       expect(mockRouter.query).toEqual(
-        options?.encoders?.columnFilters?.([]) ?? {},
+        !enabled ? {} : (options?.encoders?.columnFilters?.([]) ?? {}),
       );
     });
   });

--- a/packages/tanstack-table-search-params/src/tests/next-pages-router/columnOrder.test.ts
+++ b/packages/tanstack-table-search-params/src/tests/next-pages-router/columnOrder.test.ts
@@ -91,6 +91,10 @@ describe("columnOrder", () => {
       options: { debounceMilliseconds: { columnOrder: 1 } },
     },
     {
+      name: "with options: enabled false",
+      options: { enabled: { columnOrder: false } },
+    },
+    {
       name: "with options: custom param name, default value, debounce",
       options: {
         paramNames: { columnOrder: "COLUMN_FILTERS" },
@@ -114,6 +118,8 @@ describe("columnOrder", () => {
           : options.debounceMilliseconds
         : undefined;
 
+    const enabled = options?.enabled?.columnOrder ?? true;
+
     test("single column: string value", () => {
       const { result, rerender: resultRerender } = renderHook(() => {
         const stateAndOnChanges = useTableSearchParams(mockRouter, options);
@@ -136,7 +142,7 @@ describe("columnOrder", () => {
 
       // initial state
       expect(result.current.getState().columnOrder).toEqual(defaultColumnOrder);
-      expect(mockRouter.query).toEqual({});
+      expect(mockRouter.query).toEqual(!enabled ? {} : {});
 
       const reversed = result.current
         .getAllLeafColumns()
@@ -150,9 +156,12 @@ describe("columnOrder", () => {
 
       expect(result.current.getState().columnOrder).toEqual(reversed);
       expect(mockRouter.query).toEqual(
-        options?.encoders?.columnOrder?.(reversed) ?? {
-          [paramName]: defaultColumnOrder.length === 0 ? "name,id" : "id,name",
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.columnOrder?.(reversed) ?? {
+              [paramName]:
+                defaultColumnOrder.length === 0 ? "name,id" : "id,name",
+            }),
       );
 
       // reset
@@ -162,12 +171,14 @@ describe("columnOrder", () => {
       rerender();
 
       expect(mockRouter.query).toEqual(
-        options?.encoders?.columnOrder?.(defaultColumnOrder) ?? {
-          [paramName]:
-            defaultColumnOrder.length > 0
-              ? noneStringForCustomDefaultValue
-              : undefined,
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.columnOrder?.(defaultColumnOrder) ?? {
+              [paramName]:
+                defaultColumnOrder.length > 0
+                  ? noneStringForCustomDefaultValue
+                  : undefined,
+            }),
       );
       expect(result.current.getState().columnOrder).toEqual([]);
     });

--- a/packages/tanstack-table-search-params/src/tests/next-pages-router/columnVisibility.test.ts
+++ b/packages/tanstack-table-search-params/src/tests/next-pages-router/columnVisibility.test.ts
@@ -118,6 +118,10 @@ describe("columnVisibility", () => {
       options: { debounceMilliseconds: { columnVisibility: 1 } },
     },
     {
+      name: "with options: enabled false",
+      options: { enabled: { columnVisibility: false } },
+    },
+    {
       name: "with options: custom param name, default value, debounce",
       options: {
         paramNames: { columnVisibility: "COLUMN_VISIBILITY" },
@@ -141,6 +145,8 @@ describe("columnVisibility", () => {
           ? options.debounceMilliseconds.columnVisibility
           : options.debounceMilliseconds
         : undefined;
+
+    const enabled = options?.enabled?.columnVisibility ?? true;
 
     test("basic", () => {
       const { result, rerender: resultRerender } = renderHook(() => {
@@ -166,7 +172,7 @@ describe("columnVisibility", () => {
       expect(
         extractFalseProperties(result.current.getState().columnVisibility),
       ).toEqual(extractFalseProperties(wantInitialState));
-      expect(mockRouter.query).toEqual({});
+      expect(mockRouter.query).toEqual(!enabled ? {} : {});
 
       // toggle first column (id)
       act(() => result.current.getColumn("id")?.toggleVisibility());
@@ -179,9 +185,11 @@ describe("columnVisibility", () => {
         extractFalseProperties(result.current.getState().columnVisibility),
       ).toEqual(extractFalseProperties(wantToggledFirstColumnState));
       expect(mockRouter.query).toEqual(
-        encoder?.(wantToggledFirstColumnState) ?? {
-          [paramName]: defaultEncoder(wantToggledFirstColumnState),
-        },
+        !enabled
+          ? {}
+          : (encoder?.(wantToggledFirstColumnState) ?? {
+              [paramName]: defaultEncoder(wantToggledFirstColumnState),
+            }),
       );
 
       // toggle second column (name)
@@ -195,9 +203,11 @@ describe("columnVisibility", () => {
         extractFalseProperties(result.current.getState().columnVisibility),
       ).toEqual(extractFalseProperties(wantRetoggledFirstColumnState));
       expect(mockRouter.query).toEqual(
-        encoder?.(wantRetoggledFirstColumnState) ?? {
-          [paramName]: defaultEncoder(wantRetoggledFirstColumnState),
-        },
+        !enabled
+          ? {}
+          : (encoder?.(wantRetoggledFirstColumnState) ?? {
+              [paramName]: defaultEncoder(wantRetoggledFirstColumnState),
+            }),
       );
 
       // toggle first column (id)
@@ -211,12 +221,14 @@ describe("columnVisibility", () => {
         extractFalseProperties(result.current.getState().columnVisibility),
       ).toEqual(extractFalseProperties(wantToggledSecondColumnState));
       expect(mockRouter.query).toEqual(
-        encoder?.(wantToggledSecondColumnState) ?? {
-          [paramName]:
-            Object.keys(wantToggledSecondColumnState).length === 0
-              ? noneStringForCustomDefaultValue
-              : defaultEncoder(wantToggledSecondColumnState),
-        },
+        !enabled
+          ? {}
+          : (encoder?.(wantToggledSecondColumnState) ?? {
+              [paramName]:
+                Object.keys(wantToggledSecondColumnState).length === 0
+                  ? noneStringForCustomDefaultValue
+                  : defaultEncoder(wantToggledSecondColumnState),
+            }),
       );
 
       // toggle second column (name)
@@ -230,7 +242,7 @@ describe("columnVisibility", () => {
         extractFalseProperties(result.current.getState().columnVisibility),
       ).toEqual(extractFalseProperties(wantRetoggledSecondColumnState));
       expect(mockRouter.query).toEqual(
-        encoder?.(wantRetoggledSecondColumnState) ?? {},
+        !enabled ? {} : (encoder?.(wantRetoggledSecondColumnState) ?? {}),
       );
     });
   });

--- a/packages/tanstack-table-search-params/src/tests/next-pages-router/globalFilter.test.ts
+++ b/packages/tanstack-table-search-params/src/tests/next-pages-router/globalFilter.test.ts
@@ -73,6 +73,10 @@ describe("globalFilter", () => {
       options: { debounceMilliseconds: { globalFilter: 1 } },
     },
     {
+      name: "with options: enabled false",
+      options: { enabled: { globalFilter: false } },
+    },
+    {
       name: "with options: custom param name, default value, debounce",
       options: {
         paramNames: { globalFilter: "GLOBAL_FILTER" },
@@ -92,6 +96,8 @@ describe("globalFilter", () => {
           ? options.debounceMilliseconds.globalFilter
           : options.debounceMilliseconds
         : undefined;
+
+    const enabled = options?.enabled?.globalFilter ?? true;
 
     test("basic", () => {
       const { result, rerender: resultRerender } = renderHook(() => {
@@ -114,7 +120,9 @@ describe("globalFilter", () => {
         options?.defaultValues?.globalFilter ?? defaultDefaultGlobalFilter;
 
       // initial state
-      expect(result.current.getState().globalFilter).toBe(defaultGlobalFilter);
+      expect(result.current.getState().globalFilter).toBe(
+        !enabled ? undefined : defaultGlobalFilter,
+      );
       expect(mockRouter.query).toEqual({});
 
       // set
@@ -122,7 +130,11 @@ describe("globalFilter", () => {
       rerender();
       expect(result.current.getState().globalFilter).toBe("John");
       expect(mockRouter.query).toEqual(
-        options?.encoders?.globalFilter?.("John") ?? { [paramName]: "John" },
+        !enabled
+          ? {}
+          : (options?.encoders?.globalFilter?.("John") ?? {
+              [paramName]: "John",
+            }),
       );
 
       // reset
@@ -130,11 +142,13 @@ describe("globalFilter", () => {
       rerender();
       expect(result.current.getState().globalFilter).toBe("");
       expect(mockRouter.query).toEqual(
-        options?.encoders?.globalFilter?.("") ?? {
-          [paramName]: defaultGlobalFilter
-            ? encodedEmptyStringForGlobalFilterCustomDefaultValue
-            : undefined,
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.globalFilter?.("") ?? {
+              [paramName]: defaultGlobalFilter
+                ? encodedEmptyStringForGlobalFilterCustomDefaultValue
+                : undefined,
+            }),
       );
     });
   });

--- a/packages/tanstack-table-search-params/src/tests/next-pages-router/onStateChange.test.ts
+++ b/packages/tanstack-table-search-params/src/tests/next-pages-router/onStateChange.test.ts
@@ -305,6 +305,20 @@ describe("onStateChange", () => {
       options: { debounceMilliseconds: 1 },
     },
     {
+      name: "with options: enabled false for all states",
+      options: {
+        enabled: {
+          globalFilter: false,
+          sorting: false,
+          columnFilters: false,
+          columnOrder: false,
+          rowSelection: false,
+          columnVisibility: false,
+          pagination: false,
+        },
+      },
+    },
+    {
       name: "with options: custom param name, default value",
       options: {
         paramNames: {
@@ -362,6 +376,14 @@ describe("onStateChange", () => {
             pageSize: "pageSize",
           });
 
+    const globalFilterEnabled = options?.enabled?.globalFilter ?? true;
+    const sortingEnabled = options?.enabled?.sorting ?? true;
+    const columnFiltersEnabled = options?.enabled?.columnFilters ?? true;
+    const columnOrderEnabled = options?.enabled?.columnOrder ?? true;
+    const rowSelectionEnabled = options?.enabled?.rowSelection ?? true;
+    const columnVisibilityEnabled = options?.enabled?.columnVisibility ?? true;
+    const paginationEnabled = options?.enabled?.pagination ?? true;
+
     const { result, rerender: resultRerender } = renderHook(() => {
       const stateAndOnChanges = useTableSearchParams(mockRouter, options);
       return useReactTable({
@@ -387,7 +409,7 @@ describe("onStateChange", () => {
 
     const defaultState: TableState = {
       ...emptyState,
-      globalFilter: defaultGlobalFilter,
+      globalFilter: !globalFilterEnabled ? undefined : defaultGlobalFilter,
       sorting: defaultSorting,
       columnFilters: defaultColumnFilters,
       columnOrder: defaultColumnOrder,
@@ -422,77 +444,108 @@ describe("onStateChange", () => {
     rerender();
     expect(result.current.getState()).toStrictEqual(newState);
     expect(mockRouter.query).toEqual({
-      ...(options?.encoders?.globalFilter?.(newState.globalFilter) ?? {
-        [globalFilterParamName]: newState.globalFilter,
-      }),
-      ...(options?.encoders?.sorting?.(newState.sorting) ?? {
-        [sortingParamName]: "column1.desc",
-      }),
-      ...(options?.encoders?.columnFilters?.(newState.columnFilters) ?? {
-        [columnFiltersParamName]: "column1.%22value%22",
-      }),
-      ...(options?.encoders?.columnOrder?.(newState.columnOrder) ?? {
-        [columnOrderParamName]: "column1",
-      }),
-      ...(options?.encoders?.rowSelection?.(newState.rowSelection) ?? {
-        [rowSelectionParamName]: "row1",
-      }),
-      ...(options?.encoders?.columnVisibility?.(newState.columnVisibility) ?? {
-        [columnVisibilityParamName]: "column1",
-      }),
-      ...(options?.encoders?.pagination?.(newState.pagination) ?? {
-        [paginationParamName.pageIndex]: `${newState.pagination.pageIndex + 1}`,
-        [paginationParamName.pageSize]: `${newState.pagination.pageSize}`,
-      }),
+      ...(globalFilterEnabled
+        ? (options?.encoders?.globalFilter?.(newState.globalFilter) ?? {
+            [globalFilterParamName]: newState.globalFilter,
+          })
+        : {}),
+      ...(sortingEnabled
+        ? (options?.encoders?.sorting?.(newState.sorting) ?? {
+            [sortingParamName]: "column1.desc",
+          })
+        : {}),
+      ...(columnFiltersEnabled
+        ? (options?.encoders?.columnFilters?.(newState.columnFilters) ?? {
+            [columnFiltersParamName]: "column1.%22value%22",
+          })
+        : {}),
+      ...(columnOrderEnabled
+        ? (options?.encoders?.columnOrder?.(newState.columnOrder) ?? {
+            [columnOrderParamName]: "column1",
+          })
+        : {}),
+      ...(rowSelectionEnabled
+        ? (options?.encoders?.rowSelection?.(newState.rowSelection) ?? {
+            [rowSelectionParamName]: "row1",
+          })
+        : {}),
+      ...(columnVisibilityEnabled
+        ? (options?.encoders?.columnVisibility?.(newState.columnVisibility) ?? {
+            [columnVisibilityParamName]: "column1",
+          })
+        : {}),
+      ...(paginationEnabled
+        ? (options?.encoders?.pagination?.(newState.pagination) ?? {
+            [paginationParamName.pageIndex]: `${newState.pagination.pageIndex + 1}`,
+            [paginationParamName.pageSize]: `${newState.pagination.pageSize}`,
+          })
+        : {}),
     });
 
     act(() => result.current.reset());
     rerender();
 
-    expect(result.current.getState()).toStrictEqual(emptyState);
+    expect(result.current.getState()).toStrictEqual({
+      ...emptyState,
+      globalFilter: !globalFilterEnabled ? undefined : "",
+    });
     expect(mockRouter.query).toEqual({
-      ...(options?.encoders?.globalFilter?.("") ?? {
-        [globalFilterParamName]: defaultGlobalFilter
-          ? encodedEmptyStringForGlobalFilterCustomDefaultValue
-          : undefined,
-      }),
-      ...(options?.encoders?.sorting?.([]) ?? {
-        [sortingParamName]:
-          defaultSorting.length > 0
-            ? noneStringForCustomDefaultValue
-            : undefined,
-      }),
-      ...(options?.encoders?.columnFilters?.([]) ?? {
-        [columnFiltersParamName]:
-          defaultColumnFilters.length > 0
-            ? noneStringForCustomDefaultValue
-            : undefined,
-      }),
-      ...(options?.encoders?.columnOrder?.([]) ?? {
-        [columnOrderParamName]:
-          defaultColumnOrder.length > 0
-            ? noneStringForCustomDefaultValue
-            : undefined,
-      }),
-      ...(options?.encoders?.rowSelection?.({}) ?? {
-        [rowSelectionParamName]:
-          Object.keys(defaultRowSelection).length > 0
-            ? noneStringForCustomDefaultValue
-            : undefined,
-      }),
-      ...(options?.encoders?.columnVisibility?.(defaultColumnVisibility) ?? {
-        [columnVisibilityParamName]:
-          Object.keys(defaultColumnVisibility).length > 0
-            ? noneStringForCustomDefaultValue
-            : undefined,
-      }),
-      ...(options?.encoders?.pagination?.(defaultPagination) ??
-        (options?.defaultValues?.pagination
-          ? {
-              [paginationParamName.pageIndex]: "1",
-              [paginationParamName.pageSize]: "10",
-            }
-          : {})),
+      ...(globalFilterEnabled
+        ? (options?.encoders?.globalFilter?.("") ?? {
+            [globalFilterParamName]: defaultGlobalFilter
+              ? encodedEmptyStringForGlobalFilterCustomDefaultValue
+              : undefined,
+          })
+        : {}),
+      ...(sortingEnabled
+        ? (options?.encoders?.sorting?.([]) ?? {
+            [sortingParamName]:
+              defaultSorting.length > 0
+                ? noneStringForCustomDefaultValue
+                : undefined,
+          })
+        : {}),
+      ...(columnFiltersEnabled
+        ? (options?.encoders?.columnFilters?.([]) ?? {
+            [columnFiltersParamName]:
+              defaultColumnFilters.length > 0
+                ? noneStringForCustomDefaultValue
+                : undefined,
+          })
+        : {}),
+      ...(columnOrderEnabled
+        ? (options?.encoders?.columnOrder?.([]) ?? {
+            [columnOrderParamName]:
+              defaultColumnOrder.length > 0
+                ? noneStringForCustomDefaultValue
+                : undefined,
+          })
+        : {}),
+      ...(rowSelectionEnabled
+        ? (options?.encoders?.rowSelection?.({}) ?? {
+            [rowSelectionParamName]:
+              Object.keys(defaultRowSelection).length > 0
+                ? noneStringForCustomDefaultValue
+                : undefined,
+          })
+        : {}),
+      ...(columnVisibilityEnabled
+        ? (options?.encoders?.columnVisibility?.(defaultColumnVisibility) ?? {
+            [columnVisibilityParamName]:
+              Object.keys(defaultColumnVisibility).length > 0
+                ? noneStringForCustomDefaultValue
+                : undefined,
+          })
+        : {}),
+      ...(paginationEnabled
+        ? (options?.encoders?.pagination?.(defaultPagination) ??
+          (options?.defaultValues?.pagination
+            ? {
+                [paginationParamName.pageIndex]: "1",
+                [paginationParamName.pageSize]: "10",
+              }
+            : {}))
+        : {}),
     });
   });
 });

--- a/packages/tanstack-table-search-params/src/tests/next-pages-router/pagination.test.ts
+++ b/packages/tanstack-table-search-params/src/tests/next-pages-router/pagination.test.ts
@@ -110,6 +110,10 @@ describe("pagination", () => {
       options: { debounceMilliseconds: { pagination: 1 } },
     },
     {
+      name: "with options: enabled false",
+      options: { enabled: { pagination: false } },
+    },
+    {
       name: "with options: custom param name, default value, debounce",
       options: {
         paramNames: {
@@ -138,6 +142,8 @@ describe("pagination", () => {
           : options.debounceMilliseconds
         : undefined;
 
+    const enabled = options?.enabled?.pagination ?? true;
+
     test("basic", () => {
       const { result, rerender: resultRerender } = renderHook(() => {
         const stateAndOnChanges = useTableSearchParams(mockRouter, options);
@@ -160,7 +166,7 @@ describe("pagination", () => {
 
       // initial state
       expect(result.current.getState().pagination).toEqual(defaultPagination);
-      expect(mockRouter.query).toEqual({});
+      expect(mockRouter.query).toEqual(!enabled ? {} : {});
 
       const updatedPageSize = 20;
 
@@ -172,10 +178,12 @@ describe("pagination", () => {
         pageSize: updatedPageSize,
       });
       expect(mockRouter.query).toEqual(
-        options?.encoders?.pagination?.({
-          pageIndex: defaultPagination.pageIndex,
-          pageSize: updatedPageSize,
-        }) ?? { [paramName.pageSize]: `${updatedPageSize}` },
+        !enabled
+          ? {}
+          : (options?.encoders?.pagination?.({
+              pageIndex: defaultPagination.pageIndex,
+              pageSize: updatedPageSize,
+            }) ?? { [paramName.pageSize]: `${updatedPageSize}` }),
       );
 
       // set pageIndex
@@ -186,13 +194,15 @@ describe("pagination", () => {
         pageSize: updatedPageSize,
       });
       expect(mockRouter.query).toEqual(
-        options?.encoders?.pagination?.({
-          pageIndex: defaultPagination.pageIndex + 1,
-          pageSize: updatedPageSize,
-        }) ?? {
-          [paramName.pageIndex]: `${defaultPagination.pageIndex + 2}`,
-          [paramName.pageSize]: `${updatedPageSize}`,
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.pagination?.({
+              pageIndex: defaultPagination.pageIndex + 1,
+              pageSize: updatedPageSize,
+            }) ?? {
+              [paramName.pageIndex]: `${defaultPagination.pageIndex + 2}`,
+              [paramName.pageSize]: `${updatedPageSize}`,
+            }),
       );
 
       // reset pageIndex
@@ -203,15 +213,17 @@ describe("pagination", () => {
         pageSize: updatedPageSize,
       });
       expect(mockRouter.query).toEqual(
-        options?.encoders?.pagination?.({
-          pageIndex: 0,
-          pageSize: updatedPageSize,
-        }) ?? {
-          [paramName.pageIndex]: options?.defaultValues?.pagination
-            ? "1"
-            : undefined,
-          [paramName.pageSize]: `${updatedPageSize}`,
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.pagination?.({
+              pageIndex: 0,
+              pageSize: updatedPageSize,
+            }) ?? {
+              [paramName.pageIndex]: options?.defaultValues?.pagination
+                ? "1"
+                : undefined,
+              [paramName.pageSize]: `${updatedPageSize}`,
+            }),
       );
 
       // reset pageSize
@@ -222,10 +234,12 @@ describe("pagination", () => {
         pageSize: 10,
       });
       expect(mockRouter.query).toEqual(
-        options?.encoders?.pagination?.({ pageIndex: 0, pageSize: 10 }) ??
-          (options?.defaultValues?.pagination
-            ? { [paramName.pageIndex]: "1", [paramName.pageSize]: "10" }
-            : {}),
+        !enabled
+          ? {}
+          : (options?.encoders?.pagination?.({ pageIndex: 0, pageSize: 10 }) ??
+              (options?.defaultValues?.pagination
+                ? { [paramName.pageIndex]: "1", [paramName.pageSize]: "10" }
+                : {})),
       );
     });
   });

--- a/packages/tanstack-table-search-params/src/tests/next-pages-router/rowSelection.test.ts
+++ b/packages/tanstack-table-search-params/src/tests/next-pages-router/rowSelection.test.ts
@@ -107,6 +107,10 @@ describe("rowSelection", () => {
       options: { debounceMilliseconds: { rowSelection: 1 } },
     },
     {
+      name: "with options: enabled false",
+      options: { enabled: { rowSelection: false } },
+    },
+    {
       name: "with options: custom param name, default value, debounce",
       options: {
         paramNames: { rowSelection: "ROW_SELECTION" },
@@ -129,6 +133,8 @@ describe("rowSelection", () => {
           ? options.debounceMilliseconds.rowSelection
           : options.debounceMilliseconds
         : undefined;
+
+    const enabled = options?.enabled?.rowSelection ?? true;
 
     test("basic", () => {
       const firstRow = { id: 0, name: "John" };
@@ -154,7 +160,7 @@ describe("rowSelection", () => {
       // initial state
       const wantInitialState = defaultRowSelection;
       expect(result.current.getState().rowSelection).toEqual(wantInitialState);
-      expect(mockRouter.query).toEqual({});
+      expect(mockRouter.query).toEqual(!enabled ? {} : {});
 
       // toggle first row
       act(() => result.current.getCenterRows()[0]?.toggleSelected());
@@ -167,9 +173,11 @@ describe("rowSelection", () => {
         wantToggledFirstRowState,
       );
       expect(mockRouter.query).toEqual(
-        encoder?.(wantToggledFirstRowState) ?? {
-          [paramName]: defaultEncoder(wantToggledFirstRowState),
-        },
+        !enabled
+          ? {}
+          : (encoder?.(wantToggledFirstRowState) ?? {
+              [paramName]: defaultEncoder(wantToggledFirstRowState),
+            }),
       );
 
       // toggle second row
@@ -183,9 +191,11 @@ describe("rowSelection", () => {
         wantToggledSecondRowState,
       );
       expect(mockRouter.query).toEqual(
-        encoder?.(wantToggledSecondRowState) ?? {
-          [paramName]: defaultEncoder(wantToggledSecondRowState),
-        },
+        !enabled
+          ? {}
+          : (encoder?.(wantToggledSecondRowState) ?? {
+              [paramName]: defaultEncoder(wantToggledSecondRowState),
+            }),
       );
 
       // retoggle first row
@@ -199,12 +209,14 @@ describe("rowSelection", () => {
         wantRetoggledFirstRowState,
       );
       expect(mockRouter.query).toEqual(
-        encoder?.(wantRetoggledFirstRowState) ?? {
-          [paramName]:
-            Object.keys(wantRetoggledFirstRowState).length === 0
-              ? noneStringForCustomDefaultValue
-              : defaultEncoder(wantRetoggledFirstRowState),
-        },
+        !enabled
+          ? {}
+          : (encoder?.(wantRetoggledFirstRowState) ?? {
+              [paramName]:
+                Object.keys(wantRetoggledFirstRowState).length === 0
+                  ? noneStringForCustomDefaultValue
+                  : defaultEncoder(wantRetoggledFirstRowState),
+            }),
       );
 
       // retoggle second row
@@ -218,7 +230,7 @@ describe("rowSelection", () => {
         wantRetoggledSecondRowState,
       );
       expect(mockRouter.query).toEqual(
-        encoder?.(wantRetoggledSecondRowState) ?? {},
+        !enabled ? {} : (encoder?.(wantRetoggledSecondRowState) ?? {}),
       );
     });
   });

--- a/packages/tanstack-table-search-params/src/tests/next-pages-router/sorting.test.ts
+++ b/packages/tanstack-table-search-params/src/tests/next-pages-router/sorting.test.ts
@@ -92,6 +92,10 @@ describe("sorting", () => {
       options: { debounceMilliseconds: { sorting: 1 } },
     },
     {
+      name: "with options: enabled false",
+      options: { enabled: { sorting: false } },
+    },
+    {
       name: "with options: custom param name, default value, debounce",
       options: {
         paramNames: { sorting: "SORTING" },
@@ -115,6 +119,8 @@ describe("sorting", () => {
           : options.debounceMilliseconds
         : undefined;
 
+    const enabled = options?.enabled?.sorting ?? true;
+
     test("single column", () => {
       const { result, rerender: resultRerender } = renderHook(() => {
         const stateAndOnChanges = useTableSearchParams(mockRouter, options);
@@ -137,7 +143,7 @@ describe("sorting", () => {
 
       // initial state
       expect(result.current.getState().sorting).toEqual(defaultSorting);
-      expect(mockRouter.query).toEqual({});
+      expect(mockRouter.query).toEqual(!enabled ? {} : {});
 
       // sort by first column
       act(() =>
@@ -150,9 +156,11 @@ describe("sorting", () => {
         { id: "id", desc: true },
       ]);
       expect(mockRouter.query).toEqual(
-        options?.encoders?.sorting?.([{ id: "id", desc: true }]) ?? {
-          [paramName]: "id.desc",
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.sorting?.([{ id: "id", desc: true }]) ?? {
+              [paramName]: "id.desc",
+            }),
       );
 
       // sort by first column again
@@ -166,9 +174,11 @@ describe("sorting", () => {
         { id: "id", desc: false },
       ]);
       expect(mockRouter.query).toEqual(
-        options?.encoders?.sorting?.([{ id: "id", desc: false }]) ?? {
-          [paramName]: "id.asc",
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.sorting?.([{ id: "id", desc: false }]) ?? {
+              [paramName]: "id.asc",
+            }),
       );
 
       // sort by another column
@@ -182,9 +192,11 @@ describe("sorting", () => {
         { id: "name", desc: false },
       ]);
       expect(mockRouter.query).toEqual(
-        options?.encoders?.sorting?.([{ id: "name", desc: false }]) ?? {
-          [paramName]: "name.asc",
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.sorting?.([{ id: "name", desc: false }]) ?? {
+              [paramName]: "name.asc",
+            }),
       );
 
       // reset
@@ -202,12 +214,14 @@ describe("sorting", () => {
       rerender();
       expect(result.current.getState().sorting).toEqual([]);
       expect(mockRouter.query).toEqual(
-        options?.encoders?.sorting?.([]) ?? {
-          [paramName]:
-            defaultSorting.length > 0
-              ? noneStringForCustomDefaultValue
-              : undefined,
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.sorting?.([]) ?? {
+              [paramName]:
+                defaultSorting.length > 0
+                  ? noneStringForCustomDefaultValue
+                  : undefined,
+            }),
       );
     });
 
@@ -233,7 +247,7 @@ describe("sorting", () => {
 
       // initial state
       expect(result.current.getState().sorting).toEqual(defaultSorting);
-      expect(mockRouter.query).toEqual({});
+      expect(mockRouter.query).toEqual(!enabled ? {} : {});
 
       // sort by first column and another column
       act(() =>
@@ -253,10 +267,12 @@ describe("sorting", () => {
         { id: "name", desc: false },
       ]);
       expect(mockRouter.query).toEqual(
-        options?.encoders?.sorting?.([
-          { id: "id", desc: true },
-          { id: "name", desc: false },
-        ]) ?? { [paramName]: "id.desc,name.asc" },
+        !enabled
+          ? {}
+          : (options?.encoders?.sorting?.([
+              { id: "id", desc: true },
+              { id: "name", desc: false },
+            ]) ?? { [paramName]: "id.desc,name.asc" }),
       );
 
       // sort by first column again
@@ -271,10 +287,12 @@ describe("sorting", () => {
         { id: "name", desc: false },
       ]);
       expect(mockRouter.query).toEqual(
-        options?.encoders?.sorting?.([
-          { id: "id", desc: false },
-          { id: "name", desc: false },
-        ]) ?? { [paramName]: "id.asc,name.asc" },
+        !enabled
+          ? {}
+          : (options?.encoders?.sorting?.([
+              { id: "id", desc: false },
+              { id: "name", desc: false },
+            ]) ?? { [paramName]: "id.asc,name.asc" }),
       );
 
       // sort by another column again
@@ -288,9 +306,11 @@ describe("sorting", () => {
         { id: "id", desc: false },
       ]);
       expect(mockRouter.query).toEqual(
-        options?.encoders?.sorting?.([{ id: "id", desc: false }]) ?? {
-          [paramName]: "id.asc",
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.sorting?.([{ id: "id", desc: false }]) ?? {
+              [paramName]: "id.asc",
+            }),
       );
     });
   });

--- a/packages/tanstack-table-search-params/src/tests/onStateChange.test.ts
+++ b/packages/tanstack-table-search-params/src/tests/onStateChange.test.ts
@@ -303,6 +303,20 @@ describe("onStateChange", () => {
       options: { debounceMilliseconds: 1 },
     },
     {
+      name: "with options: enabled false for all states",
+      options: {
+        enabled: {
+          globalFilter: false,
+          sorting: false,
+          columnFilters: false,
+          columnOrder: false,
+          rowSelection: false,
+          columnVisibility: false,
+          pagination: false,
+        },
+      },
+    },
+    {
       name: "with options: custom param name, default value",
       options: {
         paramNames: {
@@ -360,6 +374,14 @@ describe("onStateChange", () => {
             pageSize: "pageSize",
           });
 
+    const globalFilterEnabled = options?.enabled?.globalFilter ?? true;
+    const sortingEnabled = options?.enabled?.sorting ?? true;
+    const columnFiltersEnabled = options?.enabled?.columnFilters ?? true;
+    const columnOrderEnabled = options?.enabled?.columnOrder ?? true;
+    const rowSelectionEnabled = options?.enabled?.rowSelection ?? true;
+    const columnVisibilityEnabled = options?.enabled?.columnVisibility ?? true;
+    const paginationEnabled = options?.enabled?.pagination ?? true;
+
     const { result: routerResult, rerender: routerRerender } = renderHook(() =>
       useTestRouter(),
     );
@@ -391,7 +413,7 @@ describe("onStateChange", () => {
 
     const defaultState: TableState = {
       ...emptyState,
-      globalFilter: defaultGlobalFilter,
+      globalFilter: !globalFilterEnabled ? undefined : defaultGlobalFilter,
       sorting: defaultSorting,
       columnFilters: defaultColumnFilters,
       columnOrder: defaultColumnOrder,
@@ -427,77 +449,108 @@ describe("onStateChange", () => {
     rerender();
     expect(result.current.getState()).toStrictEqual(newState);
     expect(routerResult.current.query).toEqual({
-      ...(options?.encoders?.globalFilter?.(newState.globalFilter) ?? {
-        [globalFilterParamName]: newState.globalFilter,
-      }),
-      ...(options?.encoders?.sorting?.(newState.sorting) ?? {
-        [sortingParamName]: "column1.desc",
-      }),
-      ...(options?.encoders?.columnFilters?.(newState.columnFilters) ?? {
-        [columnFiltersParamName]: "column1.%22value%22",
-      }),
-      ...(options?.encoders?.columnOrder?.(newState.columnOrder) ?? {
-        [columnOrderParamName]: "column1",
-      }),
-      ...(options?.encoders?.rowSelection?.(newState.rowSelection) ?? {
-        [rowSelectionParamName]: "row1",
-      }),
-      ...(options?.encoders?.columnVisibility?.(newState.columnVisibility) ?? {
-        [columnVisibilityParamName]: "column1",
-      }),
-      ...(options?.encoders?.pagination?.(newState.pagination) ?? {
-        [paginationParamName.pageIndex]: `${newState.pagination.pageIndex + 1}`,
-        [paginationParamName.pageSize]: `${newState.pagination.pageSize}`,
-      }),
+      ...(globalFilterEnabled
+        ? (options?.encoders?.globalFilter?.(newState.globalFilter) ?? {
+            [globalFilterParamName]: newState.globalFilter,
+          })
+        : {}),
+      ...(sortingEnabled
+        ? (options?.encoders?.sorting?.(newState.sorting) ?? {
+            [sortingParamName]: "column1.desc",
+          })
+        : {}),
+      ...(columnFiltersEnabled
+        ? (options?.encoders?.columnFilters?.(newState.columnFilters) ?? {
+            [columnFiltersParamName]: "column1.%22value%22",
+          })
+        : {}),
+      ...(columnOrderEnabled
+        ? (options?.encoders?.columnOrder?.(newState.columnOrder) ?? {
+            [columnOrderParamName]: "column1",
+          })
+        : {}),
+      ...(rowSelectionEnabled
+        ? (options?.encoders?.rowSelection?.(newState.rowSelection) ?? {
+            [rowSelectionParamName]: "row1",
+          })
+        : {}),
+      ...(columnVisibilityEnabled
+        ? (options?.encoders?.columnVisibility?.(newState.columnVisibility) ?? {
+            [columnVisibilityParamName]: "column1",
+          })
+        : {}),
+      ...(paginationEnabled
+        ? (options?.encoders?.pagination?.(newState.pagination) ?? {
+            [paginationParamName.pageIndex]: `${newState.pagination.pageIndex + 1}`,
+            [paginationParamName.pageSize]: `${newState.pagination.pageSize}`,
+          })
+        : {}),
     });
 
     act(() => result.current.reset());
     rerender();
 
-    expect(result.current.getState()).toStrictEqual(emptyState);
+    expect(result.current.getState()).toStrictEqual({
+      ...emptyState,
+      globalFilter: !globalFilterEnabled ? undefined : "",
+    });
     expect(routerResult.current.query).toEqual({
-      ...(options?.encoders?.globalFilter?.("") ?? {
-        [globalFilterParamName]: defaultGlobalFilter
-          ? encodedEmptyStringForGlobalFilterCustomDefaultValue
-          : undefined,
-      }),
-      ...(options?.encoders?.sorting?.([]) ?? {
-        [sortingParamName]:
-          defaultSorting.length > 0
-            ? noneStringForCustomDefaultValue
-            : undefined,
-      }),
-      ...(options?.encoders?.columnFilters?.([]) ?? {
-        [columnFiltersParamName]:
-          defaultColumnFilters.length > 0
-            ? noneStringForCustomDefaultValue
-            : undefined,
-      }),
-      ...(options?.encoders?.columnOrder?.([]) ?? {
-        [columnOrderParamName]:
-          defaultColumnOrder.length > 0
-            ? noneStringForCustomDefaultValue
-            : undefined,
-      }),
-      ...(options?.encoders?.rowSelection?.({}) ?? {
-        [rowSelectionParamName]:
-          Object.keys(defaultRowSelection).length > 0
-            ? noneStringForCustomDefaultValue
-            : undefined,
-      }),
-      ...(options?.encoders?.columnVisibility?.(defaultColumnVisibility) ?? {
-        [columnVisibilityParamName]:
-          Object.keys(defaultColumnVisibility).length > 0
-            ? noneStringForCustomDefaultValue
-            : undefined,
-      }),
-      ...(options?.encoders?.pagination?.(defaultPagination) ??
-        (options?.defaultValues?.pagination
-          ? {
-              [paginationParamName.pageIndex]: "1",
-              [paginationParamName.pageSize]: "10",
-            }
-          : {})),
+      ...(globalFilterEnabled
+        ? (options?.encoders?.globalFilter?.("") ?? {
+            [globalFilterParamName]: defaultGlobalFilter
+              ? encodedEmptyStringForGlobalFilterCustomDefaultValue
+              : undefined,
+          })
+        : {}),
+      ...(sortingEnabled
+        ? (options?.encoders?.sorting?.([]) ?? {
+            [sortingParamName]:
+              defaultSorting.length > 0
+                ? noneStringForCustomDefaultValue
+                : undefined,
+          })
+        : {}),
+      ...(columnFiltersEnabled
+        ? (options?.encoders?.columnFilters?.([]) ?? {
+            [columnFiltersParamName]:
+              defaultColumnFilters.length > 0
+                ? noneStringForCustomDefaultValue
+                : undefined,
+          })
+        : {}),
+      ...(columnOrderEnabled
+        ? (options?.encoders?.columnOrder?.([]) ?? {
+            [columnOrderParamName]:
+              defaultColumnOrder.length > 0
+                ? noneStringForCustomDefaultValue
+                : undefined,
+          })
+        : {}),
+      ...(rowSelectionEnabled
+        ? (options?.encoders?.rowSelection?.({}) ?? {
+            [rowSelectionParamName]:
+              Object.keys(defaultRowSelection).length > 0
+                ? noneStringForCustomDefaultValue
+                : undefined,
+          })
+        : {}),
+      ...(columnVisibilityEnabled
+        ? (options?.encoders?.columnVisibility?.(defaultColumnVisibility) ?? {
+            [columnVisibilityParamName]:
+              Object.keys(defaultColumnVisibility).length > 0
+                ? noneStringForCustomDefaultValue
+                : undefined,
+          })
+        : {}),
+      ...(paginationEnabled
+        ? (options?.encoders?.pagination?.(defaultPagination) ??
+          (options?.defaultValues?.pagination
+            ? {
+                [paginationParamName.pageIndex]: "1",
+                [paginationParamName.pageSize]: "10",
+              }
+            : {}))
+        : {}),
     });
   });
 });

--- a/packages/tanstack-table-search-params/src/tests/pagination.test.ts
+++ b/packages/tanstack-table-search-params/src/tests/pagination.test.ts
@@ -110,6 +110,10 @@ describe("pagination", () => {
       options: { debounceMilliseconds: { pagination: 1 } },
     },
     {
+      name: "with options: enabled false",
+      options: { enabled: { pagination: false } },
+    },
+    {
       name: "with options: custom param name, default value, debounce",
       options: {
         paramNames: {
@@ -137,6 +141,8 @@ describe("pagination", () => {
           ? options.debounceMilliseconds.pagination
           : options.debounceMilliseconds
         : undefined;
+
+    const enabled = options?.enabled?.pagination ?? true;
 
     test("basic", () => {
       const { result: routerResult, rerender: routerRerender } = renderHook(
@@ -179,10 +185,12 @@ describe("pagination", () => {
         pageSize: updatedPageSize,
       });
       expect(routerResult.current.query).toEqual(
-        options?.encoders?.pagination?.({
-          pageIndex: defaultPagination.pageIndex,
-          pageSize: updatedPageSize,
-        }) ?? { [paramName.pageSize]: `${updatedPageSize}` },
+        !enabled
+          ? {}
+          : (options?.encoders?.pagination?.({
+              pageIndex: defaultPagination.pageIndex,
+              pageSize: updatedPageSize,
+            }) ?? { [paramName.pageSize]: `${updatedPageSize}` }),
       );
 
       // set pageIndex
@@ -193,13 +201,15 @@ describe("pagination", () => {
         pageSize: updatedPageSize,
       });
       expect(routerResult.current.query).toEqual(
-        options?.encoders?.pagination?.({
-          pageIndex: defaultPagination.pageIndex + 1,
-          pageSize: updatedPageSize,
-        }) ?? {
-          [paramName.pageIndex]: `${defaultPagination.pageIndex + 2}`,
-          [paramName.pageSize]: `${updatedPageSize}`,
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.pagination?.({
+              pageIndex: defaultPagination.pageIndex + 1,
+              pageSize: updatedPageSize,
+            }) ?? {
+              [paramName.pageIndex]: `${defaultPagination.pageIndex + 2}`,
+              [paramName.pageSize]: `${updatedPageSize}`,
+            }),
       );
 
       // reset pageIndex
@@ -210,15 +220,17 @@ describe("pagination", () => {
         pageSize: updatedPageSize,
       });
       expect(routerResult.current.query).toEqual(
-        options?.encoders?.pagination?.({
-          pageIndex: 0,
-          pageSize: updatedPageSize,
-        }) ?? {
-          [paramName.pageIndex]: options?.defaultValues?.pagination
-            ? "1"
-            : undefined,
-          [paramName.pageSize]: `${updatedPageSize}`,
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.pagination?.({
+              pageIndex: 0,
+              pageSize: updatedPageSize,
+            }) ?? {
+              [paramName.pageIndex]: options?.defaultValues?.pagination
+                ? "1"
+                : undefined,
+              [paramName.pageSize]: `${updatedPageSize}`,
+            }),
       );
 
       // reset pageSize
@@ -229,10 +241,12 @@ describe("pagination", () => {
         pageSize: 10,
       });
       expect(routerResult.current.query).toEqual(
-        options?.encoders?.pagination?.({ pageIndex: 0, pageSize: 10 }) ??
-          (options?.defaultValues?.pagination
-            ? { [paramName.pageIndex]: "1", [paramName.pageSize]: "10" }
-            : {}),
+        !enabled
+          ? {}
+          : (options?.encoders?.pagination?.({ pageIndex: 0, pageSize: 10 }) ??
+              (options?.defaultValues?.pagination
+                ? { [paramName.pageIndex]: "1", [paramName.pageSize]: "10" }
+                : {})),
       );
     });
   });

--- a/packages/tanstack-table-search-params/src/tests/rowSelection.test.ts
+++ b/packages/tanstack-table-search-params/src/tests/rowSelection.test.ts
@@ -102,6 +102,10 @@ describe("rowSelection", () => {
       options: { debounceMilliseconds: { rowSelection: 1 } },
     },
     {
+      name: "with options: enabled false",
+      options: { enabled: { rowSelection: false } },
+    },
+    {
       name: "with options: custom param name, default value, debounce",
       options: {
         paramNames: { rowSelection: "ROW_SELECTION" },
@@ -124,6 +128,8 @@ describe("rowSelection", () => {
           ? options.debounceMilliseconds.rowSelection
           : options.debounceMilliseconds
         : undefined;
+
+    const enabled = options?.enabled?.rowSelection ?? true;
 
     test("basic", () => {
       const { result: routerResult, rerender: routerRerender } = renderHook(
@@ -169,9 +175,11 @@ describe("rowSelection", () => {
         wantToggledFirstRowState,
       );
       expect(routerResult.current.query).toEqual(
-        encoder?.(wantToggledFirstRowState) ?? {
-          [paramName]: defaultEncoder(wantToggledFirstRowState),
-        },
+        !enabled
+          ? {}
+          : (encoder?.(wantToggledFirstRowState) ?? {
+              [paramName]: defaultEncoder(wantToggledFirstRowState),
+            }),
       );
 
       // toggle second row
@@ -185,9 +193,11 @@ describe("rowSelection", () => {
         wantToggledSecondRowState,
       );
       expect(routerResult.current.query).toEqual(
-        encoder?.(wantToggledSecondRowState) ?? {
-          [paramName]: defaultEncoder(wantToggledSecondRowState),
-        },
+        !enabled
+          ? {}
+          : (encoder?.(wantToggledSecondRowState) ?? {
+              [paramName]: defaultEncoder(wantToggledSecondRowState),
+            }),
       );
 
       // retoggle first row
@@ -201,12 +211,14 @@ describe("rowSelection", () => {
         wantRetoggledFirstRowState,
       );
       expect(routerResult.current.query).toEqual(
-        encoder?.(wantRetoggledFirstRowState) ?? {
-          [paramName]:
-            Object.keys(wantRetoggledFirstRowState).length === 0
-              ? noneStringForCustomDefaultValue
-              : defaultEncoder(wantRetoggledFirstRowState),
-        },
+        !enabled
+          ? {}
+          : (encoder?.(wantRetoggledFirstRowState) ?? {
+              [paramName]:
+                Object.keys(wantRetoggledFirstRowState).length === 0
+                  ? noneStringForCustomDefaultValue
+                  : defaultEncoder(wantRetoggledFirstRowState),
+            }),
       );
 
       // retoggle second row
@@ -220,7 +232,7 @@ describe("rowSelection", () => {
         wantRetoggledSecondRowState,
       );
       expect(routerResult.current.query).toEqual(
-        encoder?.(wantRetoggledSecondRowState) ?? {},
+        !enabled ? {} : (encoder?.(wantRetoggledSecondRowState) ?? {}),
       );
     });
   });

--- a/packages/tanstack-table-search-params/src/tests/sorting.test.ts
+++ b/packages/tanstack-table-search-params/src/tests/sorting.test.ts
@@ -92,6 +92,10 @@ describe("sorting", () => {
       options: { debounceMilliseconds: { sorting: 1 } },
     },
     {
+      name: "with options: enabled false",
+      options: { enabled: { sorting: false } },
+    },
+    {
       name: "with options: custom param name, default value, debounce",
       options: {
         paramNames: { sorting: "SORTING" },
@@ -114,6 +118,8 @@ describe("sorting", () => {
           ? options.debounceMilliseconds.sorting
           : options.debounceMilliseconds
         : undefined;
+
+    const enabled = options?.enabled?.sorting ?? true;
 
     test("single column", () => {
       const { result: routerResult, rerender: routerRerender } = renderHook(
@@ -157,9 +163,11 @@ describe("sorting", () => {
         { id: "id", desc: true },
       ]);
       expect(routerResult.current.query).toEqual(
-        options?.encoders?.sorting?.([{ id: "id", desc: true }]) ?? {
-          [paramName]: "id.desc",
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.sorting?.([{ id: "id", desc: true }]) ?? {
+              [paramName]: "id.desc",
+            }),
       );
 
       // sort by first column again
@@ -173,9 +181,11 @@ describe("sorting", () => {
         { id: "id", desc: false },
       ]);
       expect(routerResult.current.query).toEqual(
-        options?.encoders?.sorting?.([{ id: "id", desc: false }]) ?? {
-          [paramName]: "id.asc",
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.sorting?.([{ id: "id", desc: false }]) ?? {
+              [paramName]: "id.asc",
+            }),
       );
 
       // sort by another column
@@ -189,9 +199,11 @@ describe("sorting", () => {
         { id: "name", desc: false },
       ]);
       expect(routerResult.current.query).toEqual(
-        options?.encoders?.sorting?.([{ id: "name", desc: false }]) ?? {
-          [paramName]: "name.asc",
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.sorting?.([{ id: "name", desc: false }]) ?? {
+              [paramName]: "name.asc",
+            }),
       );
 
       // reset
@@ -209,12 +221,14 @@ describe("sorting", () => {
       rerender();
       expect(result.current.getState().sorting).toEqual([]);
       expect(routerResult.current.query).toEqual(
-        options?.encoders?.sorting?.([]) ?? {
-          [paramName]:
-            defaultSorting.length > 0
-              ? noneStringForCustomDefaultValue
-              : undefined,
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.sorting?.([]) ?? {
+              [paramName]:
+                defaultSorting.length > 0
+                  ? noneStringForCustomDefaultValue
+                  : undefined,
+            }),
       );
     });
 
@@ -267,10 +281,12 @@ describe("sorting", () => {
         { id: "name", desc: false },
       ]);
       expect(routerResult.current.query).toEqual(
-        options?.encoders?.sorting?.([
-          { id: "id", desc: true },
-          { id: "name", desc: false },
-        ]) ?? { [paramName]: "id.desc,name.asc" },
+        !enabled
+          ? {}
+          : (options?.encoders?.sorting?.([
+              { id: "id", desc: true },
+              { id: "name", desc: false },
+            ]) ?? { [paramName]: "id.desc,name.asc" }),
       );
 
       // sort by first column again
@@ -285,10 +301,12 @@ describe("sorting", () => {
         { id: "name", desc: false },
       ]);
       expect(routerResult.current.query).toEqual(
-        options?.encoders?.sorting?.([
-          { id: "id", desc: false },
-          { id: "name", desc: false },
-        ]) ?? { [paramName]: "id.asc,name.asc" },
+        !enabled
+          ? {}
+          : (options?.encoders?.sorting?.([
+              { id: "id", desc: false },
+              { id: "name", desc: false },
+            ]) ?? { [paramName]: "id.asc,name.asc" }),
       );
 
       // sort by another column again
@@ -302,9 +320,11 @@ describe("sorting", () => {
         { id: "id", desc: false },
       ]);
       expect(routerResult.current.query).toEqual(
-        options?.encoders?.sorting?.([{ id: "id", desc: false }]) ?? {
-          [paramName]: "id.asc",
-        },
+        !enabled
+          ? {}
+          : (options?.encoders?.sorting?.([{ id: "id", desc: false }]) ?? {
+              [paramName]: "id.asc",
+            }),
       );
     });
   });


### PR DESCRIPTION
Add per-state `enabled` option to selectively sync table state with URL params.

fixes https://github.com/taro-28/tanstack-table-search-params/issues/579

## Example

```tsx
const stateAndOnChanges = useTableSearchParams(router, {
  // Disable synchronization of sorting
  enabled: { sorting: false },
});
```